### PR TITLE
Explain SAE and add dynamic harm-benefit conclusion to risk calculator

### DIFF
--- a/math/risk.html
+++ b/math/risk.html
@@ -420,7 +420,7 @@
                 }
 
                 el.classList.add(klass);
-                el.innerHTML = `<strong>Conclusion:</strong> you must vaccinate <strong>${nnvStr}</strong> people to prevent <strong>1</strong> hospitalization, but at a rate of 1 SAE per ${saeDen.toLocaleString()} vaccinated that same group will incur about <strong>${(nnvStr === '∞' ? '∞' : (results.nnv * results.saeRate).toFixed(2))}</strong> SAEs — i.e. <strong>${ratioStr} SAEs per prevented hospitalization</strong>. ${verdict} Note: SAE and hospitalization are both serious-tier events but not identical, and this comparison ignores other benefits (e.g. transmission reduction) and other harms (e.g. mild adverse events).`;
+                el.innerHTML = `<strong>Conclusion:</strong> you must vaccinate <strong>${nnvStr}</strong> people to prevent <strong>1</strong> hospitalization, but at a rate of 1 SAE per ${saeDen.toLocaleString()} vaccinated that same group will incur about <strong>${(nnvStr === '∞' ? '∞' : (results.nnv * results.saeRate).toFixed(2))}</strong> SAEs — i.e. <strong>${ratioStr} SAEs per prevented hospitalization</strong>. ${verdict} Caveats: SAE and hospitalization are serious-tier events but not identical; this comparison ignores milder side-effects on the harm side. It does <em>not</em> credit the vaccine with reducing transmission — the mRNA COVID‑19 vaccines do not produce sterilizing immunity, and milder symptoms in vaccinated infected people can mean a false sense of safety: people who feel healthy still shed virus and may transmit asymptomatically.`;
             }
 
             clearResults() {


### PR DESCRIPTION
## Summary

- Adds a brief definition of *Serious Adverse Event* (fatal, life-threatening, hospitalization-requiring, persistent disability, or congenital anomaly) in the Instructions block, so users see why SAE and a prevented hospitalization are compared on the same severity tier.
- Adds a colour-coded conclusion paragraph below the harm-benefit numbers that reads the current ratio and renders a verdict: green (favorable, ratio < 1), amber (mixed, 1–2), red (unfavorable, ≥ 2 or VE/hosp = 0).
- Caveat in the conclusion does **not** credit the vaccine with reducing transmission — mRNA COVID‑19 vaccines do not produce sterilizing immunity, and milder symptoms in vaccinated infected people can mask infection and enable asymptomatic onward spread.

At the default Pfizer-trial inputs (VE ≈ 95.06%, SAE 1/800, hospitalization 1/10,000) the calculator now reports ~10,520 NNV vs ~13.15 SAEs per prevented hospitalization → red verdict.

## Test plan

- [ ] Open `math/risk.html` locally; verify the SAE definition renders in the Instructions block.
- [ ] Confirm the conclusion paragraph appears below "SAE per prevented hospitalization" and is red at defaults.
- [ ] Lower the SAE rate (e.g. 1 in 100,000) and confirm the verdict turns green.
- [ ] Raise the hospitalization denominator to 1,000,000 and confirm the verdict turns red.
- [ ] Set Treatment Events = Control Events × Control Total / Treatment Total (VE = 0); confirm the "no hospitalizations prevented" branch fires.

https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U)_