### PR TITLE
Add Number Needed to Harm (NNH) below NNT in risk calculator

### DIFF
--- a/math/risk.html
+++ b/math/risk.html
@@ -258,6 +258,7 @@
             <p>Absolute Risk Reduction (ARR): <span id="arr"></span></p>
             <p>Relative Risk (RR): <span id="rr"></span></p>
             <p>Number Needed to Treat (NNT): <span id="nnt"></span></p>
+            <p>Number Needed to Harm (NNH) = 1 / SAE rate: <span id="nnh"></span></p>
             <p>Efficacy (VE) = (CER - TER) / CER × 100%: <span id="efficacy"></span></p>
         </div>
 
@@ -329,6 +330,7 @@
                 const preventedRate = hospRate * veFraction;
                 const nnv = preventedRate <= 0 ? Infinity : 1 / preventedRate;
                 const saePerPrevented = preventedRate <= 0 ? Infinity : saeRate / preventedRate;
+                const nnh = saeRate <= 0 ? Infinity : 1 / saeRate;
 
                 return {
                     cer: cer.toFixed(5),
@@ -336,6 +338,7 @@
                     arr: arr.toFixed(5),
                     rr: rr.toFixed(5),
                     nnt: Math.round(nnt),
+                    nnh,
                     efficacy: efficacy.toFixed(2),
                     saeRate,
                     saeDenominator,
@@ -354,6 +357,7 @@
                     arr: document.getElementById('arr'),
                     rr: document.getElementById('rr'),
                     nnt: document.getElementById('nnt'),
+                    nnh: document.getElementById('nnh'),
                     efficacy: document.getElementById('efficacy'),
                     saeRate: document.getElementById('saeRate'),
                     hospRate: document.getElementById('hospRate'),
@@ -374,6 +378,7 @@
                 elements.arr.textContent = `${results.arr} (${(results.arr * 100).toFixed(2)}%)`;
                 elements.rr.textContent = `${results.rr} (${(results.rr * 100).toFixed(2)}%)`;
                 elements.nnt.textContent = results.nnt === Infinity ? '∞' : results.nnt;
+                elements.nnh.textContent = results.nnh === Infinity ? '∞' : Math.round(results.nnh).toLocaleString();
                 elements.efficacy.textContent = `${results.efficacy}%`;
 
                 elements.saeRate.textContent = `1 in ${results.saeDenominator} (${(results.saeRate * 100).toFixed(4)}%)`;
@@ -425,7 +430,7 @@
 
             clearResults() {
                 this.errorDisplay.style.display = 'none';
-                const elements = ['cer', 'ter', 'arr', 'rr', 'nnt', 'efficacy',
+                const elements = ['cer', 'ter', 'arr', 'rr', 'nnt', 'nnh', 'efficacy',
                     'saeRate', 'hospRate', 'preventedRate', 'nnv', 'saePerPrevented',
                     'conclusion'];
                 elements.forEach(id => {


### PR DESCRIPTION
## Summary

- Add Number Needed to Harm (NNH) row directly below NNT in the main results panel.
- NNH = 1 / SAE rate, using the SAE-rate input as the vaccine-attributable absolute risk increase (per Fraiman et al. 2022).

## Why

NNT alone hides the harm side. Showing NNT and NNH side-by-side gives the cleanest single-number harm-benefit comparison before the harm-benefit panel translates the numbers into hospitalizations.

At default inputs:
- **NNT 141** — vaccinate 141 to prevent 1 symptomatic infection
- **NNH 800** — vaccinate 800 to cause 1 SAE

## Test plan

- [ ] Open `math/risk.html`; confirm an NNH row appears directly under NNT in the results block.
- [ ] At defaults, confirm NNH = 800 and NNT = 141.
- [ ] Change the SAE denominator to 100,000; confirm NNH updates to 100,000.
- [ ] Set SAE denominator to 1; confirm NNH = 1.

https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U)_