### PR TITLE
Compute NNH from trial-arm SAE counts and show it next to NNV

### DIFF
--- a/math/risk.html
+++ b/math/risk.html
@@ -234,11 +234,19 @@
 
         <h3 class="subhead">Harm–Benefit Inputs</h3>
         <div class="input-group">
-            <label for="saeDenominator">Vaccine SAE rate — 1 in:</label>
+            <label for="controlSAE">Control SAE Events:</label>
             <div class="value-container">
-                <input type="number" id="saeDenominator" min="1" value="800" required aria-label="Serious adverse event rate denominator">
-                <button class="arrow-btn up-btn" data-input="saeDenominator" aria-label="Increase SAE denominator" tabindex="0">↑</button>
-                <button class="arrow-btn down-btn" data-input="saeDenominator" aria-label="Decrease SAE denominator" tabindex="0">↓</button>
+                <input type="number" id="controlSAE" min="0" value="33" required aria-label="Control group SAE events">
+                <button class="arrow-btn up-btn" data-input="controlSAE" aria-label="Increase control SAE" tabindex="0">↑</button>
+                <button class="arrow-btn down-btn" data-input="controlSAE" aria-label="Decrease control SAE" tabindex="0">↓</button>
+            </div>
+        </div>
+        <div class="input-group">
+            <label for="treatmentSAE">Treatment SAE Events:</label>
+            <div class="value-container">
+                <input type="number" id="treatmentSAE" min="0" value="60" required aria-label="Treatment group SAE events">
+                <button class="arrow-btn up-btn" data-input="treatmentSAE" aria-label="Increase treatment SAE" tabindex="0">↑</button>
+                <button class="arrow-btn down-btn" data-input="treatmentSAE" aria-label="Decrease treatment SAE" tabindex="0">↓</button>
             </div>
         </div>
         <div class="input-group">
@@ -258,7 +266,10 @@
             <p>Absolute Risk Reduction (ARR): <span id="arr"></span></p>
             <p>Relative Risk (RR): <span id="rr"></span></p>
             <p>Number Needed to Treat (NNT): <span id="nnt"></span></p>
-            <p>Number Needed to Harm (NNH) = 1 / SAE rate: <span id="nnh"></span></p>
+            <p>SAE Control Rate (CER<sub>SAE</sub>): <span id="cerSae"></span></p>
+            <p>SAE Treatment Rate (TER<sub>SAE</sub>): <span id="terSae"></span></p>
+            <p>Absolute Risk Increase (ARI<sub>SAE</sub>) = TER − CER: <span id="ariSae"></span></p>
+            <p>Number Needed to Harm (NNH) = 1 / ARI<sub>SAE</sub>: <span id="nnh"></span></p>
             <p>Efficacy (VE) = (CER - TER) / CER × 100%: <span id="efficacy"></span></p>
         </div>
 
@@ -280,7 +291,7 @@
             <p>Example: If 30/100 controls and 20/100 treated had an event, enter 30, 100, 20, 100.</p>
             <p>To reset, type default values (e.g., 162, 21728, 8, 21720) — from the Pfizer–BioNTech BNT162b2 phase&nbsp;3 trial, Polack et&nbsp;al. <em>NEJM</em> 2020 (<a href="https://www.nejm.org/doi/full/10.1056/NEJMoa2034577" target="_blank" rel="noopener">NEJMoa2034577</a>, <a href="https://pubmed.ncbi.nlm.nih.gov/33301246" target="_blank" rel="noopener">PubMed 33301246</a>).</p>
             <p><strong>What is an SAE?</strong> A <em>Serious Adverse Event</em> is a medical event during a trial that is fatal, life‑threatening, requires (or prolongs) hospitalization, causes persistent or significant disability, or results in a congenital anomaly — i.e., it is on roughly the same severity tier as a COVID‑19 hospitalization, which is what makes the two figures comparable.</p>
-            <p><strong>Harm–Benefit:</strong> SAE rate defaults to 1 in 800 from Fraiman et&nbsp;al. (2022) reanalysis of mRNA COVID‑19 vaccine trials — <a href="https://pubmed.ncbi.nlm.nih.gov/36055877" target="_blank" rel="noopener">PubMed 36055877</a>. Hospitalization rate defaults to 1 in 50,000, a rough estimate for a healthy young-to-middle-aged adult per pandemic year. The calculator multiplies that rate by the trial-derived VE to estimate prevented hospitalizations per vaccinated person, then divides the SAE rate by it.</p>
+            <p><strong>Harm–Benefit:</strong> NNH is now computed from <em>trial-arm SAE counts</em> (parallel to NNT): NNH = 1 / (TER<sub>SAE</sub> − CER<sub>SAE</sub>). Default arm counts (33 control, 60 treatment on the same 21,728/21,720 totals) reproduce the headline ~1 in 800 excess SAE rate from Fraiman et&nbsp;al. (2022) reanalysis of mRNA COVID‑19 vaccine trials — <a href="https://pubmed.ncbi.nlm.nih.gov/36055877" target="_blank" rel="noopener">PubMed 36055877</a>. Hospitalization rate defaults to 1 in 50,000, a rough estimate for a healthy young-to-middle-aged adult per pandemic year. The harm-benefit panel multiplies that rate by the trial-derived VE to estimate prevented hospitalizations per vaccinated person, then divides the SAE rate by it.</p>
             <p><strong>Age stratification matters.</strong> Pre-vaccine COVID‑19 hospitalization rates spanned more than 100× by age and comorbidity. Rough per-year background rates: healthy 18–49 ≈ 1 in 10,000–50,000 · all 18–49 ≈ 1 in 1,000–2,000 · 65–74 ≈ 1 in 100–150 · 75–84 ≈ 1 in 50 · 85+ ≈ 1 in 30. Try entering 30 or 50 to see the harm-benefit balance for an elderly recipient versus 50,000 or 100,000 for a healthy young adult — the same vaccine flips between net benefit and net harm depending purely on baseline risk.</p>
         </div>
     </div>
@@ -292,17 +303,19 @@
                 this.clearResults();
             }
 
-            calculate(controlEvents, controlTotal, treatmentEvents, treatmentTotal, saeDenominator, hospDenominator) {
+            calculate(controlEvents, controlTotal, treatmentEvents, treatmentTotal, controlSAE, treatmentSAE, hospDenominator) {
                 controlEvents = Number(controlEvents);
                 controlTotal = Number(controlTotal);
                 treatmentEvents = Number(treatmentEvents);
                 treatmentTotal = Number(treatmentTotal);
-                saeDenominator = Number(saeDenominator);
+                controlSAE = Number(controlSAE);
+                treatmentSAE = Number(treatmentSAE);
                 hospDenominator = Number(hospDenominator);
 
                 if (isNaN(controlEvents) || isNaN(controlTotal) ||
                     isNaN(treatmentEvents) || isNaN(treatmentTotal) ||
-                    isNaN(saeDenominator) || isNaN(hospDenominator)) {
+                    isNaN(controlSAE) || isNaN(treatmentSAE) ||
+                    isNaN(hospDenominator)) {
                     throw new Error("All inputs must be valid numbers");
                 }
 
@@ -310,13 +323,18 @@
                     throw new Error("Totals must be greater than zero");
                 }
 
-                if (saeDenominator <= 0 || hospDenominator <= 0) {
-                    throw new Error("Rate denominators must be greater than zero");
+                if (hospDenominator <= 0) {
+                    throw new Error("Hospitalization rate denominator must be greater than zero");
                 }
 
                 if (controlEvents > controlTotal || treatmentEvents > treatmentTotal ||
                     controlEvents < 0 || treatmentEvents < 0) {
                     throw new Error("Events must be between 0 and total");
+                }
+
+                if (controlSAE > controlTotal || treatmentSAE > treatmentTotal ||
+                    controlSAE < 0 || treatmentSAE < 0) {
+                    throw new Error("SAE counts must be between 0 and total");
                 }
 
                 const cer = controlEvents / controlTotal;
@@ -326,13 +344,19 @@
                 const nnt = arr === 0 ? Infinity : Math.abs(1 / arr);
                 const efficacy = cer === 0 ? 0 : ((cer - ter) / cer) * 100;
 
-                const saeRate = 1 / saeDenominator;
+                const cerSae = controlSAE / controlTotal;
+                const terSae = treatmentSAE / treatmentTotal;
+                const ariSae = terSae - cerSae;
+                const saeRate = ariSae;
+                const nnh = ariSae <= 0 ? Infinity : 1 / ariSae;
+
                 const hospRate = 1 / hospDenominator;
                 const veFraction = efficacy / 100;
                 const preventedRate = hospRate * veFraction;
                 const nnv = preventedRate <= 0 ? Infinity : 1 / preventedRate;
-                const saePerPrevented = preventedRate <= 0 ? Infinity : saeRate / preventedRate;
-                const nnh = saeRate <= 0 ? Infinity : 1 / saeRate;
+                const saePerPrevented = preventedRate <= 0 || ariSae <= 0
+                    ? Infinity
+                    : saeRate / preventedRate;
 
                 return {
                     cer: cer.toFixed(5),
@@ -340,10 +364,12 @@
                     arr: arr.toFixed(5),
                     rr: rr.toFixed(5),
                     nnt: Math.round(nnt),
+                    cerSae,
+                    terSae,
+                    ariSae,
                     nnh,
                     efficacy: efficacy.toFixed(2),
                     saeRate,
-                    saeDenominator,
                     hospRate,
                     hospDenominator,
                     preventedRate,
@@ -359,6 +385,9 @@
                     arr: document.getElementById('arr'),
                     rr: document.getElementById('rr'),
                     nnt: document.getElementById('nnt'),
+                    cerSae: document.getElementById('cerSae'),
+                    terSae: document.getElementById('terSae'),
+                    ariSae: document.getElementById('ariSae'),
                     nnh: document.getElementById('nnh'),
                     efficacy: document.getElementById('efficacy'),
                     saeRate: document.getElementById('saeRate'),
@@ -381,10 +410,16 @@
                 elements.arr.textContent = `${results.arr} (${(results.arr * 100).toFixed(2)}%)`;
                 elements.rr.textContent = `${results.rr} (${(results.rr * 100).toFixed(2)}%)`;
                 elements.nnt.textContent = results.nnt === Infinity ? '∞' : results.nnt;
+                elements.cerSae.textContent = results.cerSae.toFixed(5);
+                elements.terSae.textContent = results.terSae.toFixed(5);
+                elements.ariSae.textContent = `${results.ariSae.toFixed(5)} (${(results.ariSae * 100).toFixed(4)}%)`;
                 elements.nnh.textContent = results.nnh === Infinity ? '∞' : Math.round(results.nnh).toLocaleString();
                 elements.efficacy.textContent = `${results.efficacy}%`;
 
-                elements.saeRate.textContent = `1 in ${results.saeDenominator} (${(results.saeRate * 100).toFixed(4)}%)`;
+                const saeRateLabel = results.saeRate <= 0
+                    ? '0 (no excess)'
+                    : `1 in ${Math.round(1 / results.saeRate).toLocaleString()} (${(results.saeRate * 100).toFixed(4)}%)`;
+                elements.saeRate.textContent = saeRateLabel;
                 elements.hospRate.textContent = `1 in ${results.hospDenominator} (${(results.hospRate * 100).toFixed(4)}%)`;
                 elements.preventedRate.textContent = results.preventedRate <= 0
                     ? '0'
@@ -402,11 +437,16 @@
                 el.classList.remove('favorable', 'mixed', 'unfavorable');
                 const ratio = results.saePerPrevented;
                 const nnv = results.nnv;
-                const saeDen = results.saeDenominator;
+                const nnh = results.nnh;
+                const nnhStr = isFinite(nnh) ? Math.round(nnh).toLocaleString() : '∞';
 
                 if (!isFinite(ratio)) {
                     el.classList.add('unfavorable');
-                    el.innerHTML = `<strong>Conclusion:</strong> the vaccine prevents no hospitalizations at these inputs (VE = 0 or hospitalization rate = 0), so every SAE is pure harm with no offsetting benefit.`;
+                    if (results.ariSae <= 0) {
+                        el.innerHTML = `<strong>Conclusion:</strong> the trial-arm SAE counts show no excess harm in the treatment group (ARI<sub>SAE</sub> ≤ 0), so the harm-benefit ratio is undefined. Adjust the SAE arm counts to see the comparison.`;
+                    } else {
+                        el.innerHTML = `<strong>Conclusion:</strong> the vaccine prevents no hospitalizations at these inputs (VE = 0 or hospitalization rate = 0), so every SAE is pure harm with no offsetting benefit.`;
+                    }
                     return;
                 }
 
@@ -429,12 +469,13 @@
                 }
 
                 el.classList.add(klass);
-                el.innerHTML = `<strong>Conclusion:</strong> you must vaccinate <strong>${nnvStr}</strong> people to prevent <strong>1</strong> hospitalization, but at a rate of 1 SAE per ${saeDen.toLocaleString()} vaccinated that same group will incur about <strong>${(nnvStr === '∞' ? '∞' : (results.nnv * results.saeRate).toFixed(2))}</strong> SAEs — i.e. <strong>${ratioStr} SAEs per prevented hospitalization</strong>. ${verdict} Caveats: SAE and hospitalization are serious-tier events but not identical; this comparison ignores milder side-effects on the harm side. It does <em>not</em> credit the vaccine with reducing transmission — the mRNA COVID‑19 vaccines do not produce sterilizing immunity, and milder symptoms in vaccinated infected people can mean a false sense of safety: people who feel healthy still shed virus and may transmit asymptomatically.`;
+                el.innerHTML = `<strong>Conclusion:</strong> you must vaccinate <strong>${nnvStr}</strong> people to prevent <strong>1</strong> hospitalization, but at the trial-derived NNH of <strong>${nnhStr}</strong> (1 SAE per ${nnhStr} vaccinated) that same group will incur about <strong>${(nnvStr === '∞' ? '∞' : (results.nnv * results.saeRate).toFixed(2))}</strong> SAEs — i.e. <strong>${ratioStr} SAEs per prevented hospitalization</strong>. ${verdict} Caveats: SAE and hospitalization are serious-tier events but not identical; this comparison ignores milder side-effects on the harm side. It does <em>not</em> credit the vaccine with reducing transmission — the mRNA COVID‑19 vaccines do not produce sterilizing immunity, and milder symptoms in vaccinated infected people can mean a false sense of safety: people who feel healthy still shed virus and may transmit asymptomatically.`;
             }
 
             clearResults() {
                 this.errorDisplay.style.display = 'none';
-                const elements = ['cer', 'ter', 'arr', 'rr', 'nnt', 'nnh', 'efficacy',
+                const elements = ['cer', 'ter', 'arr', 'rr', 'nnt',
+                    'cerSae', 'terSae', 'ariSae', 'nnh', 'efficacy',
                     'saeRate', 'hospRate', 'preventedRate', 'nnv', 'nnhPanel',
                     'saePerPrevented', 'conclusion'];
                 elements.forEach(id => {
@@ -462,7 +503,8 @@
                 const controlTotal = document.getElementById('controlTotal').value;
                 const treatmentEvents = document.getElementById('treatmentEvents').value;
                 const treatmentTotal = document.getElementById('treatmentTotal').value;
-                const saeDenominator = document.getElementById('saeDenominator').value;
+                const controlSAE = document.getElementById('controlSAE').value;
+                const treatmentSAE = document.getElementById('treatmentSAE').value;
                 const hospDenominator = document.getElementById('hospDenominator').value;
 
                 const results = calculator.calculate(
@@ -470,7 +512,8 @@
                     controlTotal,
                     treatmentEvents,
                     treatmentTotal,
-                    saeDenominator,
+                    controlSAE,
+                    treatmentSAE,
                     hospDenominator
                 );
                 calculator.displayResults(results);
@@ -506,7 +549,7 @@
 
         // Add input event listeners for real-time updates
         ['controlEvents', 'controlTotal', 'treatmentEvents', 'treatmentTotal',
-         'saeDenominator', 'hospDenominator'].forEach(id => {
+         'controlSAE', 'treatmentSAE', 'hospDenominator'].forEach(id => {
             document.getElementById(id).addEventListener('input', calculate);
         });
 

--- a/math/risk.html
+++ b/math/risk.html
@@ -268,6 +268,7 @@
             <p>Hospitalization rate without vaccine: <span id="hospRate"></span></p>
             <p>Prevented hospitalizations per vaccinated (= hosp rate × VE): <span id="preventedRate"></span></p>
             <p>Number Needed to Vaccinate to prevent 1 hospitalization: <span id="nnv"></span></p>
+            <p>Number Needed to Harm (NNH) to cause 1 SAE: <span id="nnhPanel"></span></p>
             <p><strong>SAE per prevented hospitalization:</strong> <span id="saePerPrevented"></span></p>
             <p id="conclusion" class="conclusion"></p>
         </div>
@@ -364,6 +365,7 @@
                     hospRate: document.getElementById('hospRate'),
                     preventedRate: document.getElementById('preventedRate'),
                     nnv: document.getElementById('nnv'),
+                    nnhPanel: document.getElementById('nnhPanel'),
                     saePerPrevented: document.getElementById('saePerPrevented'),
                     conclusion: document.getElementById('conclusion')
                 };
@@ -388,6 +390,7 @@
                     ? '0'
                     : `1 in ${Math.round(1 / results.preventedRate).toLocaleString()} (${(results.preventedRate * 100).toFixed(4)}%)`;
                 elements.nnv.textContent = results.nnv === Infinity ? '∞' : Math.round(results.nnv).toLocaleString();
+                elements.nnhPanel.textContent = results.nnh === Infinity ? '∞' : Math.round(results.nnh).toLocaleString();
                 elements.saePerPrevented.textContent = results.saePerPrevented === Infinity
                     ? '∞'
                     : results.saePerPrevented.toFixed(2);
@@ -432,8 +435,8 @@
             clearResults() {
                 this.errorDisplay.style.display = 'none';
                 const elements = ['cer', 'ter', 'arr', 'rr', 'nnt', 'nnh', 'efficacy',
-                    'saeRate', 'hospRate', 'preventedRate', 'nnv', 'saePerPrevented',
-                    'conclusion'];
+                    'saeRate', 'hospRate', 'preventedRate', 'nnv', 'nnhPanel',
+                    'saePerPrevented', 'conclusion'];
                 elements.forEach(id => {
                     const element = document.getElementById(id);
                     if (element) {


### PR DESCRIPTION
## Summary

- Show NNH next to NNV inside the harm-benefit panel for direct side-by-side comparison.
- **Compute NNH from trial-arm SAE counts** (parallel to NNT). Replace the single "Vaccine SAE rate — 1 in N" input with two arm-level inputs: Control SAE Events and Treatment SAE Events. NNH = 1 / (TER<sub>SAE</sub> − CER<sub>SAE</sub>).
- Add CER<sub>SAE</sub>, TER<sub>SAE</sub>, ARI<sub>SAE</sub> rows to the main results so the derivation is visible.
- Defaults 33 / 60 on the existing 21,728 / 21,720 totals reproduce the ~1 in 800 headline from Fraiman et al. (2022); user can edit any arm value.
- Conclusion text now references the live NNH instead of the removed denominator, plus a guard for ARI ≤ 0 (no excess harm in trial).

At the default inputs:
- **NNT 141** (1 prevented infection per 141 vaccinated)
- **NNH 804** (1 SAE per 804 vaccinated, computed from 60/21,720 − 33/21,728)
- **NNV 52,598** (vaccinations to prevent 1 hospitalization at 1/50,000 background)
- **~65.41 SAEs per prevented hospitalization** at the default healthy young-adult risk.

## Test plan

- [ ] Open `math/risk.html`; confirm two new SAE inputs (Control / Treatment) replace the single "1 in N" input.
- [ ] Confirm CER<sub>SAE</sub>, TER<sub>SAE</sub>, ARI<sub>SAE</sub>, NNH rows render in the results panel.
- [ ] Verify NNH = 804 at defaults and that it updates live when SAE arm counts change.
- [ ] Set Treatment SAE = Control SAE × treatmentTotal / controlTotal (ARI = 0); confirm NNH = ∞ and the conclusion shows the "no excess harm" branch.
- [ ] Confirm harm-benefit panel still shows NNV and NNH rows side by side.

https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPmA5pNUKE9WW1ovPZD17U)_