### PR TITLE
Add three physics demos: blackbody spectrum, time dilation, Kepler's third law

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,10 @@
             { title: "Carbon-14 Dating", description: "Use C-14 → N-14 radioactive decay to determine the age of organic materials like wood, bone, and charcoal", link: "physics/carbon14_dating.html" },
             { title: "Sine &amp; Cosine", description: "Explore sin and cos through the unit circle — adjust the angle and watch the waves respond", link: "math/sine_cosine.html" },
             { title: "Simpson's Paradox", description: "See how a trend within groups can reverse direction once the groups are merged — illustrated with a hand-drawn SVG chart", link: "math/simpsons_paradox.html" },
-            { title: "P-Value &amp; Confidence Interval", description: "Read the result line in any scientific abstract — see how p-values, confidence intervals, and intervals crossing zero relate", link: "math/p_value.html" }
+            { title: "P-Value &amp; Confidence Interval", description: "Read the result line in any scientific abstract — see how p-values, confidence intervals, and intervals crossing zero relate", link: "math/p_value.html" },
+            { title: "Blackbody Spectrum", description: "Watch Planck's law shift with temperature — see Wien's displacement and the T⁴ Stefan-Boltzmann scaling", link: "physics/blackbody.html" },
+            { title: "Time Dilation", description: "Explore the Lorentz factor γ — how moving clocks slow and lengths contract as you approach the speed of light", link: "physics/time_dilation.html" },
+            { title: "Kepler's Third Law", description: "Vary a planet's orbit and watch T² = a³ play out — period, perihelion, aphelion, and orbital speed", link: "physics/kepler.html" }
         ];
 
         const cardContainer = document.getElementById('cardContainer');

--- a/physics/blackbody.html
+++ b/physics/blackbody.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blackbody Spectrum (Planck's Law)</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin: 0;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+
+        .calculator {
+            width: 520px;
+            max-width: 100%;
+            background: #ffffff;
+            padding: 30px;
+            border-radius: 15px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            border: 1px solid #e5e7eb;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            color: #1e3a8a;
+            text-align: center;
+            margin-bottom: 25px;
+            font-size: 22px;
+            letter-spacing: 0.5px;
+        }
+
+        .slider-container {
+            display: flex;
+            align-items: center;
+            margin: 15px 0;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        label {
+            flex: 1;
+            color: #4b5563;
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        input[type="range"] {
+            width: 140px;
+            -webkit-appearance: none;
+            background: #d1d5db;
+            border-radius: 8px;
+            height: 6px;
+            outline: none;
+        }
+
+        input[type="range"]::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        input[type="range"]::-moz-range-thumb {
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border: none;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        .value-container {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .arrow-btn {
+            padding: 6px 10px;
+            border: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            background: #1e3a8a;
+            color: white;
+            transition: background-color 0.3s ease, transform 0.2s ease;
+        }
+
+        .arrow-btn.down {
+            background: #9ca3af;
+        }
+
+        .arrow-btn:hover {
+            transform: translateY(-2px);
+        }
+
+        .preset-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 10px 0 5px;
+        }
+
+        .preset-row button {
+            flex: 1 1 auto;
+            padding: 6px 8px;
+            font-size: 12px;
+            border: 1px solid #dbeafe;
+            border-radius: 6px;
+            background: #eff6ff;
+            color: #1e3a8a;
+            cursor: pointer;
+        }
+
+        .preset-row button:hover {
+            background: #dbeafe;
+        }
+
+        .results {
+            margin-top: 20px;
+            padding: 15px 20px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+            color: #374151;
+            font-size: 14px;
+        }
+
+        .results .row {
+            display: flex;
+            justify-content: space-between;
+            padding: 4px 0;
+        }
+
+        .results .row span:last-child {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .swatch {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            vertical-align: middle;
+            border-radius: 3px;
+            margin-left: 6px;
+            border: 1px solid #d1d5db;
+        }
+
+        canvas {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+        }
+
+        .explanation {
+            margin-top: 20px;
+            padding: 15px;
+            background: #eff6ff;
+            border-radius: 10px;
+            border: 1px solid #dbeafe;
+        }
+
+        .explanation h2 {
+            color: #1e3a8a;
+            font-size: 16px;
+            margin-bottom: 10px;
+        }
+
+        .explanation p, .explanation ul {
+            color: #6b7280;
+            font-size: 13px;
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="calculator">
+        <h1>Blackbody Spectrum (Planck's Law)</h1>
+        <div class="slider-container">
+            <label for="tempSlider">Temperature (K):</label>
+            <input type="range" id="tempSlider" min="500" max="12000" step="50" value="5778" aria-label="Adjust temperature in Kelvin">
+            <div class="value-container">
+                <span id="tempValue">5778</span>
+                <button id="upBtn" class="arrow-btn" aria-label="Increase temperature">↑</button>
+                <button id="downBtn" class="arrow-btn down" aria-label="Decrease temperature">↓</button>
+            </div>
+        </div>
+        <div class="preset-row" id="presetRow"></div>
+        <div class="results">
+            <div class="row"><span>Peak wavelength (Wien)</span><span id="peakDisplay">501 nm</span></div>
+            <div class="row"><span>Total radiated power (Stefan-Boltzmann)</span><span id="powerDisplay">— W/m²</span></div>
+            <div class="row"><span>Approximate visible color</span><span><span id="colorName">white</span><span id="colorSwatch" class="swatch"></span></span></div>
+        </div>
+        <canvas id="spectrumChart" height="220"></canvas>
+        <div class="explanation">
+            <h2>Formula</h2>
+            <p>Planck's law gives the spectral radiance \( B_\lambda \) of a blackbody at temperature \( T \) per unit wavelength:</p>
+            \[ B_\lambda(T) = \frac{2 h c^2}{\lambda^5} \cdot \frac{1}{e^{hc/(\lambda k_B T)} - 1} \]
+            <p>Two consequences fall out by integrating or differentiating:</p>
+            <ul>
+                <li><b>Wien's displacement law:</b> \( \lambda_\text{max} = b / T \), with \( b \approx 2.898\times10^{-3}\,\text{m·K} \). Hotter objects peak at shorter wavelengths.</li>
+                <li><b>Stefan-Boltzmann law:</b> \( P = \sigma T^4 \). Total radiated power per unit area scales as \( T^4 \).</li>
+            </ul>
+            <p>The Sun's surface (~5778 K) peaks in the visible green-blue (~500 nm). Incandescent bulbs (~2800 K) peak in infrared, which is why most of their energy becomes heat, not light.</p>
+        </div>
+    </div>
+
+    <script>
+        // Constants (SI)
+        const h = 6.62607015e-34;     // Planck constant J·s
+        const c = 2.99792458e8;       // speed of light m/s
+        const kB = 1.380649e-23;      // Boltzmann constant J/K
+        const sigma = 5.670374419e-8; // Stefan-Boltzmann W/m²/K⁴
+        const wienB = 2.897771955e-3; // Wien displacement m·K
+
+        const tempSlider = document.getElementById('tempSlider');
+        const tempValue = document.getElementById('tempValue');
+        const peakDisplay = document.getElementById('peakDisplay');
+        const powerDisplay = document.getElementById('powerDisplay');
+        const colorName = document.getElementById('colorName');
+        const colorSwatch = document.getElementById('colorSwatch');
+
+        // Spectral radiance per nm (W·sr⁻¹·m⁻²·nm⁻¹)
+        function planck(lambdaNm, T) {
+            const lambda = lambdaNm * 1e-9;
+            const exponent = (h * c) / (lambda * kB * T);
+            const denom = Math.exp(exponent) - 1;
+            const B = (2 * h * c * c) / Math.pow(lambda, 5) / denom; // per metre
+            return B * 1e-9; // convert to per nm for friendlier numbers
+        }
+
+        // Sample wavelengths logarithmically from 100 nm (UV) to 5000 nm (mid-IR)
+        const wavelengths = [];
+        const logMin = Math.log10(100);
+        const logMax = Math.log10(5000);
+        const steps = 240;
+        for (let i = 0; i <= steps; i++) {
+            const lambda = Math.pow(10, logMin + (logMax - logMin) * i / steps);
+            wavelengths.push(lambda);
+        }
+
+        // CIE-ish wavelength → approximate sRGB (Bruton's algorithm)
+        function wavelengthToRGB(lambda) {
+            let r = 0, g = 0, b = 0;
+            if (lambda >= 380 && lambda < 440) { r = -(lambda - 440) / 60; b = 1; }
+            else if (lambda < 490) { g = (lambda - 440) / 50; b = 1; }
+            else if (lambda < 510) { g = 1; b = -(lambda - 510) / 20; }
+            else if (lambda < 580) { r = (lambda - 510) / 70; g = 1; }
+            else if (lambda < 645) { r = 1; g = -(lambda - 645) / 65; }
+            else if (lambda <= 780) { r = 1; }
+            let factor = 0;
+            if (lambda >= 380 && lambda < 420) factor = 0.3 + 0.7 * (lambda - 380) / 40;
+            else if (lambda < 700) factor = 1;
+            else if (lambda <= 780) factor = 0.3 + 0.7 * (780 - lambda) / 80;
+            const gamma = 0.8;
+            const toByte = x => Math.round(255 * Math.pow(x * factor, gamma));
+            return [toByte(r), toByte(g), toByte(b)];
+        }
+
+        // Approximate blackbody color via summing visible spectrum × emission
+        function blackbodyColor(T) {
+            let R = 0, G = 0, Bv = 0, total = 0;
+            for (let lam = 380; lam <= 780; lam += 5) {
+                const e = planck(lam, T);
+                const [r, g, b] = wavelengthToRGB(lam);
+                R += r * e; G += g * e; Bv += b * e; total += e;
+            }
+            if (total === 0) return [0, 0, 0];
+            const max = Math.max(R, G, Bv) || 1;
+            return [
+                Math.min(255, Math.round(255 * R / max)),
+                Math.min(255, Math.round(255 * G / max)),
+                Math.min(255, Math.round(255 * Bv / max))
+            ];
+        }
+
+        function colorLabel(T) {
+            if (T < 1500) return 'deep red';
+            if (T < 2500) return 'red-orange';
+            if (T < 3500) return 'warm yellow';
+            if (T < 5000) return 'pale yellow';
+            if (T < 6500) return 'near-white';
+            if (T < 9000) return 'cool white / blue-white';
+            return 'blue';
+        }
+
+        const ctx = document.getElementById('spectrumChart').getContext('2d');
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'Spectral radiance',
+                    data: wavelengths.map(l => ({ x: l, y: planck(l, 5778) })),
+                    borderColor: '#3b82f6',
+                    backgroundColor: 'rgba(59, 130, 246, 0.15)',
+                    fill: true,
+                    pointRadius: 0,
+                    borderWidth: 2
+                }, {
+                    label: 'Visible band (380–780 nm)',
+                    data: [{ x: 380, y: 0 }, { x: 780, y: 0 }],
+                    borderColor: 'rgba(0,0,0,0)',
+                    backgroundColor: 'rgba(220, 38, 38, 0.08)',
+                    fill: true,
+                    pointRadius: 0
+                }]
+            },
+            options: {
+                animation: false,
+                scales: {
+                    x: {
+                        type: 'logarithmic',
+                        position: 'bottom',
+                        min: 100,
+                        max: 5000,
+                        title: { display: true, text: 'Wavelength (nm, log)', color: '#1f2937', font: { size: 13 } },
+                        grid: { color: '#e5e7eb' },
+                        ticks: {
+                            callback: v => [100, 200, 500, 1000, 2000, 5000].includes(v) ? v : ''
+                        }
+                    },
+                    y: {
+                        title: { display: true, text: 'Spectral radiance (W·sr⁻¹·m⁻²·nm⁻¹)', color: '#1f2937', font: { size: 12 } },
+                        grid: { color: '#e5e7eb' }
+                    }
+                },
+                plugins: {
+                    legend: { labels: { color: '#1f2937' } },
+                    title: { display: true, text: 'Planck Spectrum', color: '#1e3a8a', font: { size: 15 } }
+                }
+            }
+        });
+
+        function update() {
+            const T = parseFloat(tempSlider.value);
+            tempValue.textContent = T.toFixed(0);
+
+            const lambdaMaxNm = (wienB / T) * 1e9;
+            peakDisplay.textContent = lambdaMaxNm < 1000
+                ? `${lambdaMaxNm.toFixed(0)} nm`
+                : `${(lambdaMaxNm / 1000).toFixed(2)} µm`;
+
+            const power = sigma * Math.pow(T, 4);
+            powerDisplay.textContent = power >= 1e6
+                ? `${(power / 1e6).toFixed(2)} MW/m²`
+                : `${power.toFixed(0)} W/m²`;
+
+            const data = wavelengths.map(l => ({ x: l, y: planck(l, T) }));
+            chart.data.datasets[0].data = data;
+
+            const peakY = Math.max(...data.map(d => d.y));
+            chart.data.datasets[1].data = [{ x: 380, y: peakY * 1.05 }, { x: 780, y: peakY * 1.05 }];
+            chart.options.scales.y.suggestedMax = peakY * 1.1;
+            chart.update('none');
+
+            const [r, g, b] = blackbodyColor(T);
+            colorSwatch.style.backgroundColor = `rgb(${r}, ${g}, ${b})`;
+            colorName.textContent = colorLabel(T);
+        }
+
+        function step(dir) {
+            const s = 50;
+            let T = parseFloat(tempSlider.value);
+            T = dir === 'up' ? Math.min(12000, T + s) : Math.max(500, T - s);
+            tempSlider.value = T;
+            update();
+        }
+
+        const presets = [
+            { name: 'Candle 1900 K', T: 1900 },
+            { name: 'Bulb 2800 K', T: 2800 },
+            { name: 'Sun 5778 K', T: 5778 },
+            { name: 'Sirius 9940 K', T: 9940 }
+        ];
+        const presetRow = document.getElementById('presetRow');
+        presets.forEach(p => {
+            const btn = document.createElement('button');
+            btn.textContent = p.name;
+            btn.addEventListener('click', () => { tempSlider.value = p.T; update(); });
+            presetRow.appendChild(btn);
+        });
+
+        tempSlider.addEventListener('input', update);
+        document.getElementById('upBtn').addEventListener('click', () => step('up'));
+        document.getElementById('downBtn').addEventListener('click', () => step('down'));
+
+        update();
+    </script>
+</body>
+</html>

--- a/physics/blackbody.html
+++ b/physics/blackbody.html
@@ -194,7 +194,7 @@
         <h1>Blackbody Spectrum (Planck's Law)</h1>
         <div class="slider-container">
             <label for="tempSlider">Temperature (K):</label>
-            <input type="range" id="tempSlider" min="500" max="12000" step="50" value="5778" aria-label="Adjust temperature in Kelvin">
+            <input type="range" id="tempSlider" min="500" max="12000" step="1" value="5778" aria-label="Adjust temperature in Kelvin">
             <div class="value-container">
                 <span id="tempValue">5778</span>
                 <button id="upBtn" class="arrow-btn" aria-label="Increase temperature">↑</button>

--- a/physics/kepler.html
+++ b/physics/kepler.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kepler's Third Law — Orbital Period</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin: 0;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+
+        .calculator {
+            width: 540px;
+            max-width: 100%;
+            background: #ffffff;
+            padding: 30px;
+            border-radius: 15px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            border: 1px solid #e5e7eb;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            color: #1e3a8a;
+            text-align: center;
+            margin-bottom: 25px;
+            font-size: 22px;
+        }
+
+        .slider-container {
+            display: flex;
+            align-items: center;
+            margin: 15px 0;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        label {
+            flex: 1;
+            color: #4b5563;
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        input[type="range"] {
+            width: 160px;
+            -webkit-appearance: none;
+            background: #d1d5db;
+            border-radius: 8px;
+            height: 6px;
+            outline: none;
+        }
+
+        input[type="range"]::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        input[type="range"]::-moz-range-thumb {
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border: none;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        .value-container {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .arrow-btn {
+            padding: 6px 10px;
+            border: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            background: #1e3a8a;
+            color: white;
+        }
+
+        .arrow-btn.down { background: #9ca3af; }
+        .arrow-btn:hover { transform: translateY(-2px); }
+
+        .preset-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 10px 0 5px;
+        }
+
+        .preset-row button {
+            flex: 1 1 auto;
+            padding: 6px 8px;
+            font-size: 12px;
+            border: 1px solid #dbeafe;
+            border-radius: 6px;
+            background: #eff6ff;
+            color: #1e3a8a;
+            cursor: pointer;
+        }
+
+        .preset-row button:hover { background: #dbeafe; }
+
+        .results {
+            margin-top: 20px;
+            padding: 15px 20px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+            color: #374151;
+            font-size: 14px;
+        }
+
+        .results .row {
+            display: flex;
+            justify-content: space-between;
+            padding: 4px 0;
+        }
+
+        .results .row span:last-child {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .orbit-stage {
+            margin-top: 20px;
+            padding: 10px;
+            background: #0b1220;
+            border-radius: 10px;
+            border: 1px solid #1e3a8a;
+            display: flex;
+            justify-content: center;
+        }
+
+        canvas.chart {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+        }
+
+        .explanation {
+            margin-top: 20px;
+            padding: 15px;
+            background: #eff6ff;
+            border-radius: 10px;
+            border: 1px solid #dbeafe;
+        }
+
+        .explanation h2 {
+            color: #1e3a8a;
+            font-size: 16px;
+            margin-bottom: 10px;
+        }
+
+        .explanation p, .explanation ul {
+            color: #6b7280;
+            font-size: 13px;
+            margin: 5px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="calculator">
+        <h1>Kepler's Third Law — Orbital Period</h1>
+
+        <div class="slider-container">
+            <label for="aSlider">Semi-major axis a (AU):</label>
+            <input type="range" id="aSlider" min="0.2" max="40" step="0.01" value="1" aria-label="Adjust semi-major axis in AU">
+            <div class="value-container">
+                <span id="aValue">1.00 AU</span>
+                <button id="aUp" class="arrow-btn" aria-label="Increase axis">↑</button>
+                <button id="aDown" class="arrow-btn down" aria-label="Decrease axis">↓</button>
+            </div>
+        </div>
+
+        <div class="slider-container">
+            <label for="eSlider">Eccentricity e:</label>
+            <input type="range" id="eSlider" min="0" max="0.95" step="0.01" value="0.0167" aria-label="Adjust eccentricity">
+            <div class="value-container">
+                <span id="eValue">0.017</span>
+                <button id="eUp" class="arrow-btn" aria-label="Increase eccentricity">↑</button>
+                <button id="eDown" class="arrow-btn down" aria-label="Decrease eccentricity">↓</button>
+            </div>
+        </div>
+
+        <div class="slider-container">
+            <label for="mSlider">Central mass (M☉):</label>
+            <input type="range" id="mSlider" min="0.1" max="10" step="0.01" value="1" aria-label="Adjust central mass">
+            <div class="value-container">
+                <span id="mValue">1.00 M☉</span>
+                <button id="mUp" class="arrow-btn" aria-label="Increase mass">↑</button>
+                <button id="mDown" class="arrow-btn down" aria-label="Decrease mass">↓</button>
+            </div>
+        </div>
+
+        <div class="preset-row" id="presetRow"></div>
+
+        <div class="results">
+            <div class="row"><span>Orbital period</span><span id="periodDisplay">1.00 yr</span></div>
+            <div class="row"><span>Perihelion / aphelion</span><span id="apsisDisplay">0.98 / 1.02 AU</span></div>
+            <div class="row"><span>Mean orbital speed</span><span id="speedDisplay">29.78 km/s</span></div>
+        </div>
+
+        <div class="orbit-stage">
+            <canvas id="orbitCanvas" width="500" height="280" aria-label="Orbit diagram"></canvas>
+        </div>
+
+        <canvas id="periodChart" class="chart" height="220"></canvas>
+
+        <div class="explanation">
+            <h2>Formula</h2>
+            <p>Kepler's third law, generalised by Newton, relates the orbital period \(T\) to the semi-major axis \(a\) and the central mass \(M\):</p>
+            \[ T^2 = \frac{4 \pi^2}{G M} a^3 \]
+            <p>Around the Sun (\(M = 1\,M_\odot\)) with \(a\) in AU and \(T\) in years this collapses to the famous</p>
+            \[ T^2 = a^3 \]
+            <p>Eccentricity \(e\) doesn't change the period — orbits with the same \(a\) take the same time, no matter their shape. It only changes the perihelion (\(a(1-e)\)) and aphelion (\(a(1+e)\)) distances. The mean orbital speed scales as \(\sqrt{M/a}\); Mercury sprints while Neptune crawls.</p>
+            <ul>
+                <li>Earth: a = 1 AU → T = 1 yr ✓</li>
+                <li>Mars: a = 1.524 AU → T ≈ 1.88 yr</li>
+                <li>Jupiter: a = 5.20 AU → T ≈ 11.86 yr</li>
+                <li>Neptune: a = 30.07 AU → T ≈ 164.8 yr</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        const G = 6.67430e-11;            // m³/kg/s²
+        const M_sun = 1.98892e30;          // kg
+        const AU = 1.495978707e11;         // m
+        const YEAR = 365.25 * 86400;       // s
+
+        const aSlider = document.getElementById('aSlider');
+        const eSlider = document.getElementById('eSlider');
+        const mSlider = document.getElementById('mSlider');
+        const aValue = document.getElementById('aValue');
+        const eValue = document.getElementById('eValue');
+        const mValue = document.getElementById('mValue');
+        const periodDisplay = document.getElementById('periodDisplay');
+        const apsisDisplay = document.getElementById('apsisDisplay');
+        const speedDisplay = document.getElementById('speedDisplay');
+
+        function periodYears(aAU, mSolar) {
+            const aMeters = aAU * AU;
+            const M = mSolar * M_sun;
+            const Tsec = 2 * Math.PI * Math.sqrt(Math.pow(aMeters, 3) / (G * M));
+            return Tsec / YEAR;
+        }
+
+        function meanSpeed(aAU, mSolar) {
+            const aMeters = aAU * AU;
+            const M = mSolar * M_sun;
+            const v = Math.sqrt(G * M / aMeters); // m/s
+            return v / 1000; // km/s
+        }
+
+        // --- Period vs a curve ---
+        const aSamples = [];
+        const periodSamples = [];
+        for (let i = 0; i <= 200; i++) {
+            const a = Math.pow(10, -1 + (1.7 + 1) * i / 200); // 0.1 to ~50 AU
+            aSamples.push(a);
+            periodSamples.push(periodYears(a, parseFloat(mSlider.value)));
+        }
+
+        const ctx = document.getElementById('periodChart').getContext('2d');
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'Period vs a (current mass)',
+                    data: aSamples.map((a, i) => ({ x: a, y: periodSamples[i] })),
+                    borderColor: '#3b82f6',
+                    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                    fill: false,
+                    pointRadius: 0,
+                    borderWidth: 2
+                }, {
+                    label: 'Current',
+                    type: 'scatter',
+                    data: [{ x: 1, y: 1 }],
+                    pointBackgroundColor: '#dc2626',
+                    pointRadius: 5
+                }, {
+                    label: 'Solar System planets',
+                    type: 'scatter',
+                    data: [
+                        { x: 0.387, y: 0.241 }, // Mercury
+                        { x: 0.723, y: 0.615 }, // Venus
+                        { x: 1.000, y: 1.000 }, // Earth
+                        { x: 1.524, y: 1.881 }, // Mars
+                        { x: 5.203, y: 11.86 }, // Jupiter
+                        { x: 9.537, y: 29.46 }, // Saturn
+                        { x: 19.19, y: 84.01 }, // Uranus
+                        { x: 30.07, y: 164.8 }  // Neptune
+                    ],
+                    pointBackgroundColor: '#f59e0b',
+                    pointRadius: 4
+                }]
+            },
+            options: {
+                animation: false,
+                scales: {
+                    x: {
+                        type: 'logarithmic',
+                        title: { display: true, text: 'Semi-major axis a (AU, log)', color: '#1f2937' },
+                        grid: { color: '#e5e7eb' },
+                        min: 0.1, max: 50,
+                        ticks: { callback: v => [0.1, 1, 10].includes(v) ? v : '' }
+                    },
+                    y: {
+                        type: 'logarithmic',
+                        title: { display: true, text: 'Period T (years, log)', color: '#1f2937' },
+                        grid: { color: '#e5e7eb' },
+                        min: 0.01, max: 1000,
+                        ticks: { callback: v => [0.01, 0.1, 1, 10, 100, 1000].includes(v) ? v : '' }
+                    }
+                },
+                plugins: {
+                    legend: { labels: { color: '#1f2937' } },
+                    title: { display: true, text: "T² = a³ — log-log slope of 3/2", color: '#1e3a8a', font: { size: 15 } }
+                }
+            }
+        });
+
+        // --- Orbit diagram ---
+        const orbitCanvas = document.getElementById('orbitCanvas');
+        const octx = orbitCanvas.getContext('2d');
+
+        function drawOrbit(aAU, e) {
+            const W = orbitCanvas.width;
+            const H = orbitCanvas.height;
+            octx.clearRect(0, 0, W, H);
+
+            // Star at right focus (so perihelion is on the right at +a(1-e))
+            // Ellipse parameters in canvas space; we just normalise axis to fit
+            const margin = 30;
+            const maxR = Math.min(W, H) / 2 - margin;
+            const b = aAU * Math.sqrt(1 - e * e);
+            const scale = maxR / aAU; // pixels per AU
+            const cx = W / 2;
+            const cy = H / 2;
+
+            // Star (focus offset by c = a*e)
+            const focusOffsetPx = aAU * e * scale;
+            const starX = cx + focusOffsetPx;
+            const starY = cy;
+
+            // Orbit ellipse (centre at canvas centre)
+            octx.beginPath();
+            octx.ellipse(cx, cy, aAU * scale, b * scale, 0, 0, 2 * Math.PI);
+            octx.strokeStyle = '#3b82f6';
+            octx.lineWidth = 1.5;
+            octx.stroke();
+
+            // Major axis (perihelion–aphelion line)
+            octx.beginPath();
+            octx.moveTo(cx - aAU * scale, cy);
+            octx.lineTo(cx + aAU * scale, cy);
+            octx.strokeStyle = 'rgba(255,255,255,0.18)';
+            octx.setLineDash([4, 4]);
+            octx.stroke();
+            octx.setLineDash([]);
+
+            // Star
+            octx.beginPath();
+            octx.arc(starX, starY, 8, 0, 2 * Math.PI);
+            const starGrad = octx.createRadialGradient(starX, starY, 1, starX, starY, 12);
+            starGrad.addColorStop(0, '#fff7c4');
+            starGrad.addColorStop(0.6, '#f59e0b');
+            starGrad.addColorStop(1, 'rgba(245, 158, 11, 0)');
+            octx.fillStyle = starGrad;
+            octx.fill();
+
+            // Planet — animate over period (visual only)
+            const t = (performance.now() / 3000) % (2 * Math.PI);
+            // Solve Kepler's equation E - e sin E = M (Newton)
+            let E = t;
+            for (let i = 0; i < 8; i++) E = E - (E - e * Math.sin(E) - t) / (1 - e * Math.cos(E));
+            const px = cx + aAU * scale * (Math.cos(E) - e);
+            const py = cy + b * scale * Math.sin(E);
+
+            octx.beginPath();
+            octx.arc(px, py, 5, 0, 2 * Math.PI);
+            octx.fillStyle = '#60a5fa';
+            octx.fill();
+
+            // Labels
+            octx.fillStyle = 'rgba(255,255,255,0.55)';
+            octx.font = '11px sans-serif';
+            octx.textAlign = 'center';
+            octx.fillText(`a = ${aAU.toFixed(2)} AU,  e = ${e.toFixed(3)}`, cx, H - 10);
+        }
+
+        function update() {
+            const a = parseFloat(aSlider.value);
+            const e = parseFloat(eSlider.value);
+            const m = parseFloat(mSlider.value);
+
+            aValue.textContent = `${a.toFixed(2)} AU`;
+            eValue.textContent = e.toFixed(3);
+            mValue.textContent = `${m.toFixed(2)} M☉`;
+
+            const T = periodYears(a, m);
+            periodDisplay.textContent = T < 1 ? `${(T * 365.25).toFixed(1)} days` : `${T.toFixed(2)} yr`;
+            apsisDisplay.textContent = `${(a * (1 - e)).toFixed(3)} / ${(a * (1 + e)).toFixed(3)} AU`;
+            speedDisplay.textContent = `${meanSpeed(a, m).toFixed(2)} km/s`;
+
+            // Update curve to current mass
+            const newPeriods = aSamples.map(av => periodYears(av, m));
+            chart.data.datasets[0].data = aSamples.map((av, i) => ({ x: av, y: newPeriods[i] }));
+            chart.data.datasets[1].data = [{ x: a, y: T }];
+            chart.update('none');
+        }
+
+        function step(slider, valueEl, dir, formatter, big) {
+            const s = parseFloat(slider.step) * (big ? 10 : 1);
+            const max = parseFloat(slider.max);
+            const min = parseFloat(slider.min);
+            let v = parseFloat(slider.value);
+            v = dir === 'up' ? Math.min(max, v + s) : Math.max(min, v - s);
+            slider.value = v;
+            update();
+        }
+
+        const presets = [
+            { name: 'Mercury', a: 0.387, e: 0.2056 },
+            { name: 'Earth', a: 1.000, e: 0.0167 },
+            { name: 'Mars', a: 1.524, e: 0.0934 },
+            { name: 'Jupiter', a: 5.203, e: 0.0489 },
+            { name: 'Halley', a: 17.83, e: 0.967 },
+            { name: 'Neptune', a: 30.07, e: 0.0086 }
+        ];
+        const presetRow = document.getElementById('presetRow');
+        presets.forEach(p => {
+            const btn = document.createElement('button');
+            btn.textContent = p.name;
+            btn.addEventListener('click', () => {
+                aSlider.value = p.a;
+                eSlider.value = p.e;
+                mSlider.value = 1;
+                update();
+            });
+            presetRow.appendChild(btn);
+        });
+
+        aSlider.addEventListener('input', update);
+        eSlider.addEventListener('input', update);
+        mSlider.addEventListener('input', update);
+        document.getElementById('aUp').addEventListener('click', () => step(aSlider, aValue, 'up', null, true));
+        document.getElementById('aDown').addEventListener('click', () => step(aSlider, aValue, 'down', null, true));
+        document.getElementById('eUp').addEventListener('click', () => step(eSlider, eValue, 'up'));
+        document.getElementById('eDown').addEventListener('click', () => step(eSlider, eValue, 'down'));
+        document.getElementById('mUp').addEventListener('click', () => step(mSlider, mValue, 'up', null, true));
+        document.getElementById('mDown').addEventListener('click', () => step(mSlider, mValue, 'down', null, true));
+
+        update();
+
+        // Animation loop for the orbit diagram only
+        function tick() {
+            drawOrbit(parseFloat(aSlider.value), parseFloat(eSlider.value));
+            requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+    </script>
+</body>
+</html>

--- a/physics/kepler.html
+++ b/physics/kepler.html
@@ -422,7 +422,7 @@
             mValue.textContent = `${m.toFixed(2)} M☉`;
 
             const T = periodYears(a, m);
-            periodDisplay.textContent = T < 1 ? `${(T * 365.25).toFixed(1)} days` : `${T.toFixed(2)} yr`;
+            periodDisplay.textContent = T < 0.995 ? `${(T * 365.25).toFixed(1)} days` : `${T.toFixed(2)} yr`;
             apsisDisplay.textContent = `${(a * (1 - e)).toFixed(3)} / ${(a * (1 + e)).toFixed(3)} AU`;
             speedDisplay.textContent = `${meanSpeed(a, m).toFixed(2)} km/s`;
 

--- a/physics/time_dilation.html
+++ b/physics/time_dilation.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Relativistic Time Dilation</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin: 0;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+
+        .calculator {
+            width: 520px;
+            max-width: 100%;
+            background: #ffffff;
+            padding: 30px;
+            border-radius: 15px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            border: 1px solid #e5e7eb;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            color: #1e3a8a;
+            text-align: center;
+            margin-bottom: 25px;
+            font-size: 22px;
+        }
+
+        .slider-container {
+            display: flex;
+            align-items: center;
+            margin: 15px 0;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        label {
+            flex: 1;
+            color: #4b5563;
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        input[type="range"] {
+            width: 160px;
+            -webkit-appearance: none;
+            background: #d1d5db;
+            border-radius: 8px;
+            height: 6px;
+            outline: none;
+        }
+
+        input[type="range"]::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        input[type="range"]::-moz-range-thumb {
+            width: 16px;
+            height: 16px;
+            background: #3b82f6;
+            border: none;
+            border-radius: 50%;
+            cursor: pointer;
+        }
+
+        .value-container {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .arrow-btn {
+            padding: 6px 10px;
+            border: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            background: #1e3a8a;
+            color: white;
+        }
+
+        .arrow-btn.down {
+            background: #9ca3af;
+        }
+
+        .arrow-btn:hover { transform: translateY(-2px); }
+
+        .preset-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 10px 0 5px;
+        }
+
+        .preset-row button {
+            flex: 1 1 auto;
+            padding: 6px 8px;
+            font-size: 12px;
+            border: 1px solid #dbeafe;
+            border-radius: 6px;
+            background: #eff6ff;
+            color: #1e3a8a;
+            cursor: pointer;
+        }
+
+        .preset-row button:hover { background: #dbeafe; }
+
+        .results {
+            margin-top: 20px;
+            padding: 15px 20px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+            color: #374151;
+            font-size: 14px;
+        }
+
+        .results .row {
+            display: flex;
+            justify-content: space-between;
+            padding: 4px 0;
+        }
+
+        .results .row span:last-child {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        canvas {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+        }
+
+        .explanation {
+            margin-top: 20px;
+            padding: 15px;
+            background: #eff6ff;
+            border-radius: 10px;
+            border: 1px solid #dbeafe;
+        }
+
+        .explanation h2 {
+            color: #1e3a8a;
+            font-size: 16px;
+            margin-bottom: 10px;
+        }
+
+        .explanation p, .explanation ul {
+            color: #6b7280;
+            font-size: 13px;
+            margin: 5px 0;
+        }
+
+        .unit-toggle {
+            display: flex;
+            gap: 6px;
+            margin-bottom: 5px;
+        }
+
+        .unit-toggle button {
+            padding: 5px 10px;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            background: #f3f4f6;
+            color: #4b5563;
+            cursor: pointer;
+            font-size: 12px;
+        }
+
+        .unit-toggle button.active {
+            background: #1e3a8a;
+            color: white;
+            border-color: #1e3a8a;
+        }
+    </style>
+</head>
+<body>
+    <div class="calculator">
+        <h1>Relativistic Time Dilation</h1>
+
+        <div class="unit-toggle" role="tablist" aria-label="Velocity unit">
+            <button id="unitFraction" class="active" aria-pressed="true">v / c</button>
+            <button id="unitKms" aria-pressed="false">km/s</button>
+        </div>
+
+        <div class="slider-container">
+            <label for="velocitySlider">Velocity:</label>
+            <input type="range" id="velocitySlider" min="0" max="0.999999" step="0.0001" value="0.5" aria-label="Adjust velocity">
+            <div class="value-container">
+                <span id="velocityValue">0.5000 c</span>
+                <button id="upBtn" class="arrow-btn" aria-label="Increase velocity">↑</button>
+                <button id="downBtn" class="arrow-btn down" aria-label="Decrease velocity">↓</button>
+            </div>
+        </div>
+
+        <div class="preset-row" id="presetRow"></div>
+
+        <div class="results">
+            <div class="row"><span>Lorentz factor γ</span><span id="gammaDisplay">1.155</span></div>
+            <div class="row"><span>Time dilation: 1 yr on ship =</span><span id="dilatedDisplay">1.155 yr Earth</span></div>
+            <div class="row"><span>Length contraction: 1 m =</span><span id="lengthDisplay">0.866 m</span></div>
+            <div class="row"><span>Relativistic mass factor</span><span id="massDisplay">1.155</span></div>
+        </div>
+
+        <canvas id="gammaChart" height="220"></canvas>
+
+        <div class="explanation">
+            <h2>Formula</h2>
+            <p>Special relativity says a clock moving at velocity \(v\) ticks slower as observed from a stationary frame, by the Lorentz factor:</p>
+            \[ \gamma = \frac{1}{\sqrt{1 - v^2/c^2}} \]
+            <p>So a proper time interval \(\Delta\tau\) on the moving clock corresponds to \(\Delta t = \gamma\,\Delta\tau\) in the stationary frame. Lengths along the direction of motion contract by \(1/\gamma\), and the kinetic-energy-equivalent mass scales as \(\gamma m_0\).</p>
+            <ul>
+                <li>At everyday speeds (a jetliner ≈ 250 m/s), \(\gamma \approx 1 + 3.5\times10^{-13}\) — tiny but measurable with atomic clocks (Hafele-Keating, 1971).</li>
+                <li>At \(0.5c\), γ ≈ 1.155 — only ~15% slowdown.</li>
+                <li>At \(0.99c\), γ ≈ 7.09 — strong dilation.</li>
+                <li>As \(v \to c\), \(\gamma \to \infty\) — infinite energy required, which is why \(c\) is a hard limit for massive objects.</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        const c_kms = 299792.458;
+
+        const velocitySlider = document.getElementById('velocitySlider');
+        const velocityValue = document.getElementById('velocityValue');
+        const gammaDisplay = document.getElementById('gammaDisplay');
+        const dilatedDisplay = document.getElementById('dilatedDisplay');
+        const lengthDisplay = document.getElementById('lengthDisplay');
+        const massDisplay = document.getElementById('massDisplay');
+        const unitFractionBtn = document.getElementById('unitFraction');
+        const unitKmsBtn = document.getElementById('unitKms');
+
+        let unit = 'fraction'; // or 'kms'
+
+        function gamma(beta) {
+            if (beta >= 1) return Infinity;
+            return 1 / Math.sqrt(1 - beta * beta);
+        }
+
+        // Build curve up to β = 0.999
+        const betas = [];
+        const gammas = [];
+        for (let i = 0; i <= 200; i++) {
+            const b = i / 200 * 0.999;
+            betas.push(b);
+            gammas.push(gamma(b));
+        }
+
+        const ctx = document.getElementById('gammaChart').getContext('2d');
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'γ vs β',
+                    data: betas.map((b, i) => ({ x: b, y: gammas[i] })),
+                    borderColor: '#3b82f6',
+                    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                    fill: false,
+                    pointRadius: 0,
+                    borderWidth: 2
+                }, {
+                    label: 'Current',
+                    type: 'scatter',
+                    data: [{ x: 0.5, y: gamma(0.5) }],
+                    pointBackgroundColor: '#dc2626',
+                    pointRadius: 5
+                }]
+            },
+            options: {
+                animation: false,
+                scales: {
+                    x: {
+                        type: 'linear',
+                        min: 0, max: 1,
+                        title: { display: true, text: 'β = v / c', color: '#1f2937' },
+                        grid: { color: '#e5e7eb' }
+                    },
+                    y: {
+                        min: 1, max: 10,
+                        title: { display: true, text: 'Lorentz factor γ', color: '#1f2937' },
+                        grid: { color: '#e5e7eb' }
+                    }
+                },
+                plugins: {
+                    legend: { labels: { color: '#1f2937' } },
+                    title: { display: true, text: 'Lorentz factor γ vs velocity', color: '#1e3a8a', font: { size: 15 } }
+                }
+            }
+        });
+
+        function setUnit(u) {
+            unit = u;
+            unitFractionBtn.classList.toggle('active', u === 'fraction');
+            unitKmsBtn.classList.toggle('active', u === 'kms');
+            unitFractionBtn.setAttribute('aria-pressed', u === 'fraction');
+            unitKmsBtn.setAttribute('aria-pressed', u === 'kms');
+
+            if (u === 'fraction') {
+                velocitySlider.min = 0;
+                velocitySlider.max = 0.999999;
+                velocitySlider.step = 0.0001;
+            } else {
+                velocitySlider.min = 0;
+                velocitySlider.max = c_kms * 0.999999;
+                velocitySlider.step = 100;
+            }
+            update();
+        }
+
+        function getBeta() {
+            const v = parseFloat(velocitySlider.value);
+            return unit === 'fraction' ? v : v / c_kms;
+        }
+
+        function update() {
+            const beta = getBeta();
+            const g = gamma(beta);
+
+            if (unit === 'fraction') {
+                velocityValue.textContent = `${beta.toFixed(4)} c`;
+            } else {
+                const v = parseFloat(velocitySlider.value);
+                velocityValue.textContent = `${v.toFixed(0)} km/s`;
+            }
+
+            gammaDisplay.textContent = isFinite(g) ? g.toFixed(4) : '∞';
+            dilatedDisplay.textContent = isFinite(g) ? `${g.toFixed(4)} yr Earth` : '∞';
+            lengthDisplay.textContent = isFinite(g) ? `${(1 / g).toFixed(4)} m` : '0 m';
+            massDisplay.textContent = isFinite(g) ? g.toFixed(4) : '∞';
+
+            chart.data.datasets[1].data = [{ x: Math.min(beta, 0.999), y: Math.min(isFinite(g) ? g : 1e3, 10) }];
+            chart.update('none');
+        }
+
+        function step(dir) {
+            let v = parseFloat(velocitySlider.value);
+            const s = parseFloat(velocitySlider.step);
+            const max = parseFloat(velocitySlider.max);
+            v = dir === 'up' ? Math.min(max, v + s) : Math.max(0, v - s);
+            velocitySlider.value = v;
+            update();
+        }
+
+        const presets = [
+            { name: 'Jetliner 250 m/s', beta: 250 / (c_kms * 1000) },
+            { name: 'ISS 7.66 km/s', beta: 7.66 / c_kms },
+            { name: '0.1 c', beta: 0.1 },
+            { name: '0.9 c', beta: 0.9 },
+            { name: '0.99 c', beta: 0.99 },
+            { name: '0.999 c', beta: 0.999 }
+        ];
+        const presetRow = document.getElementById('presetRow');
+        presets.forEach(p => {
+            const btn = document.createElement('button');
+            btn.textContent = p.name;
+            btn.addEventListener('click', () => {
+                if (unit === 'fraction') {
+                    velocitySlider.value = p.beta;
+                } else {
+                    velocitySlider.value = p.beta * c_kms;
+                }
+                update();
+            });
+            presetRow.appendChild(btn);
+        });
+
+        velocitySlider.addEventListener('input', update);
+        document.getElementById('upBtn').addEventListener('click', () => step('up'));
+        document.getElementById('downBtn').addEventListener('click', () => step('down'));
+        unitFractionBtn.addEventListener('click', () => setUnit('fraction'));
+        unitKmsBtn.addEventListener('click', () => setUnit('kms'));
+
+        update();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- physics/blackbody.html: Planck's law visualizer with temperature slider,
  Wien's peak wavelength, Stefan-Boltzmann total power, and an approximate
  visible-color swatch. Presets for candle / bulb / Sun / Sirius.
- physics/time_dilation.html: Lorentz factor γ vs velocity (β as fraction
  of c, or km/s), with derived time dilation, length contraction, and
  relativistic mass scaling. Solar-System and near-c presets.
- physics/kepler.html: T² = a³ orbital-period calculator with eccentricity
  and central-mass sliders, an animated orbit (Kepler's equation solved
  by Newton's method), and a log-log plot showing the actual planets.

All three use the existing site conventions (inline CSS/JS, Chart.js +
MathJax via CDN, blue palette, gradient background) and are linked from
the landing page.