### PR TITLE
Adopt IBM Carbon design system from design.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,17 @@ Static HTML/CSS/JavaScript educational demos — no framework, no bundler, no pa
 - `math/` — Bayes' Theorem calculator, RPN stack calculator, Risk/NNT calculator
 - `physics/` — Planet effective temperature calculator (Stefan-Boltzmann law)
 
-Each demo is a self-contained `.html` file with all CSS and JavaScript inline. External dependencies (Chart.js for graphs, MathJax for LaTeX rendering) are loaded via CDN.
+Each demo is a self-contained `.html` file with inline CSS and JavaScript, plus a shared `styles.css` at the repo root that carries the design system. External dependencies (Chart.js for graphs, MathJax for LaTeX rendering) are loaded via CDN.
 
-**Design conventions**: gradient backgrounds (`#e0e7ff` → `#f3f4f6`), blue palette (`#1e3a8a` primary, `#3b82f6` accent), responsive via CSS media queries, semantic HTML with ARIA labels.
+## Design system
+
+**`design.md` is the source of truth for all visual design.** It documents the IBM Carbon Design System adopted for this site (palette, typography, spacing, components). When making any UI/visual change, read `design.md` first and follow its tokens; do not reintroduce the old gradient/rounded look.
+
+Key tokens (mirrored as CSS variables in `styles.css`):
+- Primary accent: IBM Blue `#0f62fe` — used only for primary CTAs, links, focused-input underlines.
+- Surfaces: white canvas `#ffffff`, light gray `#f4f4f4`, charcoal footer `#161616`.
+- Text: ink `#161616`, ink-muted `#525252`.
+- Type: IBM Plex Sans (weight 300 for display 42px+, 400 for body, 600 for emphasis), `letter-spacing: 0.16px` on body.
+- Geometry: square corners (`border-radius: 0`) on every button, card, input, container. No drop shadows.
+
+`styles.css` provides shared base styles, `.ibm-*` utility classes (top-nav, page shell, tile grid, hero, footer, buttons, inputs), and mobile safety rules that prevent horizontal page scroll so range sliders capture touch drags correctly.

--- a/index.html
+++ b/index.html
@@ -3,131 +3,53 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Insights of Math and Physics</title>
+    <title>Insights — Math &amp; Physics</title>
+    <link rel="stylesheet" href="styles.css">
     <style>
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
-            min-height: 100vh;
+        body { background: var(--ibm-canvas); }
+        .topics-eyebrow {
             display: flex;
-            justify-content: center;
-            align-items: center;
-            margin: 0;
-            padding: 10px;
-            box-sizing: border-box;
-        }
-
-        .card-container {
-            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 24px;
+            margin-bottom: 32px;
             flex-wrap: wrap;
-            gap: 20px;
-            max-width: 1200px;
-            width: 100%;
-            padding: 20px;
-            justify-content: center;
-            box-sizing: border-box;
         }
-
-        .card {
-            background-color: #f9fafb;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-            width: 200px;
-            min-width: 180px;
-            padding: 20px;
-            text-align: center;
-            text-decoration: none;
-            color: #333;
-            transition: box-shadow 0.2s ease, background-color 0.2s ease;
-            flex: 1 1 200px;
-            max-width: 250px;
-        }
-
-        .card:hover {
-            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-            background-color: #ffffff;
-        }
-
-        .card h3 {
-            margin: 0 0 10px;
-            color: #1e3a8a;
-            font-size: 18px;
-        }
-
-        .card p {
+        .topics-eyebrow h2 {
+            font-size: 32px;
+            font-weight: 400;
+            line-height: 1.25;
             margin: 0;
+        }
+        .topics-eyebrow .ibm-eyebrow {
             font-size: 14px;
-            color: #6b7280;
+            letter-spacing: 0.16px;
+            color: var(--ibm-ink-muted);
+            margin: 0;
         }
-
-        /* Responsive adjustments */
-        @media (max-width: 900px) {
-            .card-container {
-                gap: 15px;
-                padding: 15px;
-            }
-
-            .card {
-                width: 180px;
-                padding: 15px;
-                flex: 1 1 180px;
-                max-width: 220px;
-            }
-
-            .card h3 {
-                font-size: 16px;
-            }
-
-            .card p {
-                font-size: 13px;
-            }
+        .topic-filter {
+            display: flex;
+            gap: 0;
+            border-bottom: 1px solid var(--ibm-hairline);
+            margin-bottom: 32px;
         }
-
-        @media (max-width: 600px) {
-            .card-container {
-                flex-direction: column;
-                align-items: center;
-                gap: 10px;
-                padding: 10px;
-            }
-
-            .card {
-                width: 100%;
-                max-width: 300px;
-                padding: 12px;
-                flex: 1 1 auto;
-            }
-
-            .card h3 {
-                font-size: 15px;
-            }
-
-            .card p {
-                font-size: 12px;
-            }
+        .topic-filter button {
+            background: transparent;
+            border: 0;
+            padding: 16px 20px;
+            font-family: var(--ibm-font);
+            font-size: 14px;
+            color: var(--ibm-ink-muted);
+            letter-spacing: 0.16px;
+            cursor: pointer;
+            border-bottom: 2px solid transparent;
+            margin-bottom: -1px;
         }
-
-        @media (max-width: 400px) {
-            body {
-                padding: 5px;
-            }
-
-            .card-container {
-                padding: 5px;
-            }
-
-            .card {
-                padding: 10px;
-            }
-
-            .card h3 {
-                font-size: 14px;
-                margin-bottom: 8px;
-            }
-
-            .card p {
-                font-size: 11px;
-            }
+        .topic-filter button:hover { color: var(--ibm-ink); }
+        .topic-filter button.active {
+            color: var(--ibm-ink);
+            font-weight: 600;
+            border-bottom-color: var(--ibm-primary);
         }
     </style>
     <!-- pwa-install-marker -->
@@ -136,49 +58,104 @@
     <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png">
     <link rel="manifest" href="manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
     <meta name="mobile-web-app-capable" content="yes">
     <script src="pwa.js" defer></script>
-
 </head>
 <body>
-    <div class="card-container" id="cardContainer"></div>
+    <div class="ibm-utility-bar" role="region" aria-label="Site utility">
+        <span>Interactive learning · Math &amp; Physics</span>
+    </div>
+    <header class="ibm-top-nav" role="banner">
+        <div class="ibm-wordmark"><a href="index.html">Insights</a></div>
+        <nav aria-label="Primary">
+            <a href="#topics">Topics</a>
+            <a href="#math">Math</a>
+            <a href="#physics">Physics</a>
+        </nav>
+    </header>
+
+    <main class="ibm-page">
+        <section class="ibm-hero">
+            <p class="ibm-eyebrow">Interactive demos</p>
+            <h1>Insights for math and physics, one calculator at a time.</h1>
+            <p class="ibm-lead">A collection of small, self-contained tools that turn formulas into something you can poke at — Bayes' theorem, Stefan-Boltzmann, Kepler's third law, and more.</p>
+        </section>
+
+        <section class="ibm-section" id="topics">
+            <div class="topics-eyebrow">
+                <h2>Browse the demos</h2>
+                <p class="ibm-eyebrow">Sixteen interactive pages</p>
+            </div>
+            <div class="topic-filter" role="tablist" aria-label="Filter by topic">
+                <button class="active" data-filter="all" role="tab">All</button>
+                <button data-filter="math" role="tab">Math</button>
+                <button data-filter="physics" role="tab">Physics</button>
+            </div>
+            <div class="ibm-card-grid" id="cardContainer"></div>
+        </section>
+    </main>
+
+    <footer class="ibm-footer" role="contentinfo">
+        <div class="ibm-footer-inner">
+            <p class="ibm-wordmark">Insights</p>
+            <p>Interactive math &amp; physics demos.</p>
+            <p>Static site, no tracking, no build.</p>
+        </div>
+    </footer>
 
     <script>
         const pages = [
-            { title: "Reverse Polish Notation", description: "Demo of the stack in Reverse Polish Notation", link: "math/polish.html" },
-            { title: "Linear Regression", description: "Find the line of best fit through data points and explore slope, intercept, and R²", link: "math/linear_regression.html" },
-            { title: "Exponential Functions", description: "Explore growth and decay with y = a·eᵇˣ — adjust parameters and see doubling time or half-life", link: "math/exponential.html" },
-            { title: "Bayes Theorem", description: "Demo of Bayes' Theorem", link: "math/bayes.html" },
-            { title: "Absolute and Relative Risk", description: "Calculating efficacy, risk, and Number Needed to Treat (NNT)", link: "math/risk.html" },
-            { title: "Earth Temperature", description: "Calculating Earth's temperature with Stefan-Boltzmann law by varying albedo", link: "physics/earth_temperature.html" },
-            { title: "Simple Equations", description: "Explore linear and quadratic equations — adjust parameters, visualize graphs, and solve for x", link: "math/equations.html" },
-            { title: "K-Ar Rock Dating", description: "Use Potassium-40 → Argon-40 radioactive decay to determine the age of igneous rocks", link: "physics/decay_dating.html" },
-            { title: "Carbon-14 Dating", description: "Use C-14 → N-14 radioactive decay to determine the age of organic materials like wood, bone, and charcoal", link: "physics/carbon14_dating.html" },
-            { title: "Sine &amp; Cosine", description: "Explore sin and cos through the unit circle — adjust the angle and watch the waves respond", link: "math/sine_cosine.html" },
-            { title: "Simpson's Paradox", description: "See how a trend within groups can reverse direction once the groups are merged — illustrated with a hand-drawn SVG chart", link: "math/simpsons_paradox.html" },
-            { title: "P-Value &amp; Confidence Interval", description: "Read the result line in any scientific abstract — see how p-values, confidence intervals, and intervals crossing zero relate", link: "math/p_value.html" },
-            { title: "Central Limit Theorem", description: "Watch sample means turn into a bell curve no matter how strange the source distribution — the foundation behind p-values, CIs, and polling", link: "math/clt.html" },
-            { title: "Blackbody Spectrum", description: "Watch Planck's law shift with temperature — see Wien's displacement and the T⁴ Stefan-Boltzmann scaling", link: "physics/blackbody.html" },
-            { title: "Time Dilation", description: "Explore the Lorentz factor γ — how moving clocks slow and lengths contract as you approach the speed of light", link: "physics/time_dilation.html" },
-            { title: "Kepler's Third Law", description: "Vary a planet's orbit and watch T² = a³ play out — period, perihelion, aphelion, and orbital speed", link: "physics/kepler.html" }
+            { title: "Reverse Polish Notation", description: "Demo of the stack in Reverse Polish Notation", link: "math/polish.html", topic: "math" },
+            { title: "Linear Regression", description: "Find the line of best fit through data points and explore slope, intercept, and R squared.", link: "math/linear_regression.html", topic: "math" },
+            { title: "Exponential Functions", description: "Explore growth and decay with y = a·e^(bx) — adjust parameters and see doubling time or half-life.", link: "math/exponential.html", topic: "math" },
+            { title: "Bayes' Theorem", description: "Demo of Bayes' Theorem.", link: "math/bayes.html", topic: "math" },
+            { title: "Absolute and Relative Risk", description: "Calculating efficacy, risk, and Number Needed to Treat (NNT).", link: "math/risk.html", topic: "math" },
+            { title: "Earth Temperature", description: "Calculating Earth's temperature with the Stefan-Boltzmann law by varying albedo.", link: "physics/earth_temperature.html", topic: "physics" },
+            { title: "Simple Equations", description: "Explore linear and quadratic equations — adjust parameters, visualize graphs, and solve for x.", link: "math/equations.html", topic: "math" },
+            { title: "K-Ar Rock Dating", description: "Use Potassium-40 to Argon-40 radioactive decay to determine the age of igneous rocks.", link: "physics/decay_dating.html", topic: "physics" },
+            { title: "Carbon-14 Dating", description: "Use C-14 to N-14 radioactive decay to determine the age of organic materials such as wood, bone, and charcoal.", link: "physics/carbon14_dating.html", topic: "physics" },
+            { title: "Sine and Cosine", description: "Explore sin and cos through the unit circle — adjust the angle and watch the waves respond.", link: "math/sine_cosine.html", topic: "math" },
+            { title: "Simpson's Paradox", description: "See how a trend within groups can reverse direction once the groups are merged.", link: "math/simpsons_paradox.html", topic: "math" },
+            { title: "P-Value &amp; Confidence Interval", description: "Read the result line in any scientific abstract — see how p-values, confidence intervals, and intervals crossing zero relate.", link: "math/p_value.html", topic: "math" },
+            { title: "Central Limit Theorem", description: "Watch sample means turn into a bell curve regardless of the source distribution.", link: "math/clt.html", topic: "math" },
+            { title: "Blackbody Spectrum", description: "Watch Planck's law shift with temperature — see Wien's displacement and the T to the fourth Stefan-Boltzmann scaling.", link: "physics/blackbody.html", topic: "physics" },
+            { title: "Time Dilation", description: "Explore the Lorentz factor — how moving clocks slow and lengths contract as you approach the speed of light.", link: "physics/time_dilation.html", topic: "physics" },
+            { title: "Kepler's Third Law", description: "Vary a planet's orbit and watch T squared equals a cubed play out — period, perihelion, aphelion, and orbital speed.", link: "physics/kepler.html", topic: "physics" }
         ];
 
         const cardContainer = document.getElementById('cardContainer');
 
-        pages.forEach(page => {
-            const card = document.createElement('a');
-            card.className = 'card';
-            card.href = page.link;
-            card.setAttribute('aria-label', `View ${page.title} demo`);
-            card.innerHTML = `
-                <h3>${page.title}</h3>
-                <p>${page.description}</p>
-            `;
-            cardContainer.appendChild(card);
+        function render(filter) {
+            cardContainer.innerHTML = '';
+            pages
+                .filter(p => filter === 'all' || p.topic === filter)
+                .forEach(page => {
+                    const card = document.createElement('a');
+                    card.className = 'ibm-tile';
+                    card.href = page.link;
+                    card.setAttribute('aria-label', `Open ${page.title}`);
+                    card.innerHTML = `
+                        <p class="ibm-tile-eyebrow">${page.topic === 'math' ? 'Math' : 'Physics'}</p>
+                        <h3>${page.title}</h3>
+                        <p>${page.description}</p>
+                        <span class="ibm-tile-arrow">Open →</span>
+                    `;
+                    cardContainer.appendChild(card);
+                });
+        }
+
+        render('all');
+
+        document.querySelectorAll('.topic-filter button').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.topic-filter button').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                render(btn.dataset.filter);
+            });
         });
     </script>
 </body>

--- a/math/bayes.html
+++ b/math/bayes.html
@@ -6,8 +6,8 @@
     <title>Bayes' Theorem Calculator</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,14 +22,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 24px;
@@ -46,7 +46,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
             min-width: 120px;
@@ -55,8 +55,8 @@
         input {
             width: 100px;
             padding: 8px 12px;
-            border: 1px solid #d1d5db;
-            border-radius: 8px;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
             font-size: 14px;
             transition: border-color 0.3s ease, box-shadow 0.3s ease;
             flex-grow: 1;
@@ -65,8 +65,8 @@
 
         input:focus {
             outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+            border-color: #0f62fe;
+            box-shadow: none;
         }
 
         .value-container {
@@ -78,7 +78,7 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -86,36 +86,36 @@
         }
 
         .up-btn {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         .up-btn:hover {
-            background: #1e40af;
+            background: #0050e6;
             transform: translateY(-2px);
         }
 
         .down-btn {
-            background: #9ca3af;
+            background: #8c8c8c;
             color: white;
         }
 
         .down-btn:hover {
-            background: #6b7280;
+            background: #525252;
             transform: translateY(-2px);
         }
 
         #results {
             margin-top: 25px;
             padding: 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         #results p {
             margin: 10px 0;
-            color: #374151;
+            color: #161616;
             font-size: 14px;
             display: flex;
             justify-content: space-between;
@@ -124,13 +124,13 @@
 
         #results span {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         .fraction {
             display: inline-block;
             text-align: center;
-            color: #374151;
+            color: #161616;
             font-size: 13px;
             margin-left: 10px;
         }
@@ -141,19 +141,19 @@
 
         .formula {
             margin: 5px 0;
-            color: #374151;
+            color: #161616;
             font-size: 14px;
         }
 
         .formula-description {
             margin: 5px 0 10px;
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
         }
 
         .table-note {
             margin: 5px 0;
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
         }
 
@@ -165,14 +165,14 @@
         }
 
         .confusion-table th, .confusion-table td {
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
             padding: 8px;
             text-align: center;
-            color: #374151;
+            color: #161616;
         }
 
         .confusion-table th {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
             font-weight: 600;
         }
@@ -182,7 +182,7 @@
         }
 
         #error {
-            color: #dc2626;
+            color: #da1e28;
             font-size: 13px;
             margin-top: 10px;
             display: none;
@@ -192,19 +192,19 @@
         .instructions {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .instructions h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .instructions p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
@@ -357,13 +357,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">

--- a/math/clt.html
+++ b/math/clt.html
@@ -6,8 +6,8 @@
     <title>Central Limit Theorem</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,14 +22,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -38,13 +38,13 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 22px;
         }
 
         h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin: 24px 0 10px;
         }
@@ -60,10 +60,10 @@
             flex: 1 1 auto;
             min-width: 120px;
             padding: 10px 12px;
-            border: 1px solid #dbeafe;
-            background: #eff6ff;
-            color: #1e3a8a;
-            border-radius: 8px;
+            border: 1px solid #edf5ff;
+            background: #f4f4f4;
+            color: #0f62fe;
+            border-radius: 0;
             font-size: 13px;
             font-weight: 600;
             cursor: pointer;
@@ -71,14 +71,14 @@
         }
 
         .scenarios button:hover {
-            background: #dbeafe;
+            background: #edf5ff;
             transform: translateY(-1px);
         }
 
         .scenarios button.active {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
-            border-color: #1e3a8a;
+            border-color: #0f62fe;
         }
 
         .controls {
@@ -101,20 +101,20 @@
         }
 
         .control-row label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
         }
 
         .control-row .value {
-            color: #1f2937;
+            color: #161616;
             font-size: 13px;
             font-variant-numeric: tabular-nums;
         }
 
         .control-row input[type="range"] {
             width: 100%;
-            accent-color: #1e3a8a;
+            accent-color: #0f62fe;
         }
 
         .actions {
@@ -127,10 +127,10 @@
             flex: 1 1 auto;
             min-width: 60px;
             padding: 8px 10px;
-            border: 1px solid #dbeafe;
-            background: #eff6ff;
-            color: #1e3a8a;
-            border-radius: 6px;
+            border: 1px solid #edf5ff;
+            background: #f4f4f4;
+            color: #0f62fe;
+            border-radius: 0;
             font-size: 13px;
             font-weight: 600;
             cursor: pointer;
@@ -138,7 +138,7 @@
         }
 
         .actions button:hover {
-            background: #dbeafe;
+            background: #edf5ff;
         }
 
         .actions button.reset {
@@ -152,22 +152,22 @@
         }
 
         .chart-wrap {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 14px 12px 8px;
             margin-bottom: 14px;
         }
 
         .chart-title {
-            color: #374151;
+            color: #161616;
             font-size: 13px;
             font-weight: 600;
             margin: 0 4px 6px;
         }
 
         .chart-note {
-            color: #6b7280;
+            color: #525252;
             font-size: 12px;
             margin: 4px 4px 0;
         }
@@ -186,14 +186,14 @@
         }
 
         .stat {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 10px 12px;
         }
 
         .stat .label {
-            color: #6b7280;
+            color: #525252;
             font-size: 11px;
             text-transform: uppercase;
             letter-spacing: 0.5px;
@@ -201,7 +201,7 @@
         }
 
         .stat .num {
-            color: #1f2937;
+            color: #161616;
             font-size: 18px;
             font-weight: 700;
             font-variant-numeric: tabular-nums;
@@ -209,19 +209,19 @@
         }
 
         .stat .num.muted {
-            color: #9ca3af;
+            color: #8c8c8c;
         }
 
         .explainer {
             margin-top: 26px;
             padding: 18px 20px;
-            background: #eff6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
         }
 
         .explainer p {
-            color: #374151;
+            color: #161616;
             font-size: 13.5px;
             line-height: 1.55;
             margin: 0 0 10px;
@@ -232,22 +232,22 @@
         }
 
         .explainer code {
-            background: #dbeafe;
-            color: #1e3a8a;
+            background: #edf5ff;
+            color: #0f62fe;
             padding: 1px 6px;
-            border-radius: 4px;
+            border-radius: 0;
             font-size: 12.5px;
         }
 
         .explainer .tag {
             display: inline-block;
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
             font-size: 11px;
             font-weight: 700;
             letter-spacing: 0.5px;
             padding: 2px 8px;
-            border-radius: 4px;
+            border-radius: 0;
             margin-right: 6px;
             vertical-align: 1px;
         }
@@ -258,13 +258,14 @@
             .container { padding: 18px; }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -469,8 +470,8 @@
             for (let t = tStart; t <= xmax + 1e-9; t += step) ticks.push(+t.toFixed(6));
             return ticks.map(t => {
                 const x = xS(t);
-                return `<line x1="${x}" y1="${yBase}" x2="${x}" y2="${yBase + 4}" stroke="#9ca3af"/>` +
-                       `<text x="${x}" y="${yBase + 16}" text-anchor="middle" font-size="11" fill="#6b7280">${t}</text>`;
+                return `<line x1="${x}" y1="${yBase}" x2="${x}" y2="${yBase + 4}" stroke="#8c8c8c"/>` +
+                       `<text x="${x}" y="${yBase + 16}" text-anchor="middle" font-size="11" fill="#525252">${t}</text>`;
             }).join('');
         }
 
@@ -494,7 +495,7 @@
                     const cx = xS(x);
                     const y0 = yS(p);
                     const y1 = yS(0);
-                    return `<rect x="${cx - barW / 2}" y="${y0}" width="${barW}" height="${(y1 - y0).toFixed(1)}" fill="#3b82f6" fill-opacity="0.45" stroke="#1e3a8a" stroke-width="1"/>`;
+                    return `<rect x="${cx - barW / 2}" y="${y0}" width="${barW}" height="${(y1 - y0).toFixed(1)}" fill="#0f62fe" fill-opacity="0.45" stroke="#0f62fe" stroke-width="1"/>`;
                 }).join('');
             } else {
                 const N = 220;
@@ -508,15 +509,15 @@
                                  pts.map(p => p[0].toFixed(1) + ' ' + p[1].toFixed(1)).join(' L') +
                                  ` L${pts[pts.length - 1][0].toFixed(1)} ${(m.t + ph).toFixed(1)} Z`;
                 densityMarkup =
-                    `<path d="${fillPath}" fill="#3b82f6" fill-opacity="0.18" stroke="none"/>` +
-                    `<path d="${curvePath}" fill="none" stroke="#1e3a8a" stroke-width="2"/>`;
+                    `<path d="${fillPath}" fill="#0f62fe" fill-opacity="0.18" stroke="none"/>` +
+                    `<path d="${curvePath}" fill="none" stroke="#0f62fe" stroke-width="2"/>`;
             }
 
             // Population mean line
             const meanX = xS(src.mean);
             const meanLine =
-                `<line x1="${meanX}" y1="${m.t}" x2="${meanX}" y2="${m.t + ph}" stroke="#1e3a8a" stroke-width="1.5" stroke-dasharray="4 3"/>` +
-                `<text x="${meanX}" y="${m.t + 12}" text-anchor="middle" font-size="11" font-weight="700" fill="#1e3a8a">μ = ${fmt(src.mean, 2)}</text>`;
+                `<line x1="${meanX}" y1="${m.t}" x2="${meanX}" y2="${m.t + ph}" stroke="#0f62fe" stroke-width="1.5" stroke-dasharray="4 3"/>` +
+                `<text x="${meanX}" y="${m.t + 12}" text-anchor="middle" font-size="11" font-weight="700" fill="#0f62fe">μ = ${fmt(src.mean, 2)}</text>`;
 
             // Last sample marks
             let sampleMarkup = '';
@@ -524,18 +525,18 @@
                 const yDot = m.t + ph - 6;
                 sampleMarkup = state.lastSample.map(x => {
                     const cx = xS(Math.max(xmin, Math.min(xmax, x)));
-                    return `<circle cx="${cx.toFixed(1)}" cy="${yDot}" r="3.6" fill="#dc2626" fill-opacity="0.75" stroke="white" stroke-width="1"/>`;
+                    return `<circle cx="${cx.toFixed(1)}" cy="${yDot}" r="3.6" fill="#da1e28" fill-opacity="0.75" stroke="white" stroke-width="1"/>`;
                 }).join('');
                 const sm = state.lastSample.reduce((s, v) => s + v, 0) / state.lastSample.length;
                 const cx = xS(Math.max(xmin, Math.min(xmax, sm))).toFixed(1);
                 const cy = (m.t + ph - 18).toFixed(1);
-                sampleMarkup += `<g transform="rotate(45 ${cx} ${cy})"><rect x="${cx - 6}" y="${cy - 6}" width="12" height="12" fill="#1e3a8a" stroke="white" stroke-width="1.5"/></g>`;
+                sampleMarkup += `<g transform="rotate(45 ${cx} ${cy})"><rect x="${cx - 6}" y="${cy - 6}" width="12" height="12" fill="#0f62fe" stroke="white" stroke-width="1.5"/></g>`;
             }
 
             // Frame & ticks
-            const frame = `<rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e5e7eb"/>`;
+            const frame = `<rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e0e0e0"/>`;
             const ticks = xTicks(xmin, xmax, xS, m.t + ph, m, pw);
-            const xLabel = `<text x="${m.l + pw / 2}" y="${h - 6}" text-anchor="middle" font-size="12" fill="#4b5563">value of an individual draw</text>`;
+            const xLabel = `<text x="${m.l + pw / 2}" y="${h - 6}" text-anchor="middle" font-size="12" fill="#525252">value of an individual draw</text>`;
 
             els.popChart.innerHTML = frame + densityMarkup + meanLine + sampleMarkup + ticks + xLabel;
         }
@@ -574,7 +575,7 @@
                     const x1 = xS(xmin + (i + 1) * binW);
                     const y0 = yS(densities[i]);
                     const y1 = yS(0);
-                    bars += `<rect x="${x0.toFixed(1)}" y="${y0.toFixed(1)}" width="${(x1 - x0).toFixed(1)}" height="${(y1 - y0).toFixed(1)}" fill="#3b82f6" fill-opacity="0.55" stroke="#1e3a8a" stroke-width="0.4"/>`;
+                    bars += `<rect x="${x0.toFixed(1)}" y="${y0.toFixed(1)}" width="${(x1 - x0).toFixed(1)}" height="${(y1 - y0).toFixed(1)}" fill="#0f62fe" fill-opacity="0.55" stroke="#0f62fe" stroke-width="0.4"/>`;
                 }
             }
 
@@ -590,25 +591,25 @@
             // Mean line
             const meanX = xS(src.mean);
             const meanLine =
-                `<line x1="${meanX}" y1="${m.t}" x2="${meanX}" y2="${m.t + ph}" stroke="#1e3a8a" stroke-width="1.5" stroke-dasharray="4 3"/>` +
-                `<text x="${meanX}" y="${m.t + 12}" text-anchor="middle" font-size="11" font-weight="700" fill="#1e3a8a">μ = ${fmt(src.mean, 2)}</text>`;
+                `<line x1="${meanX}" y1="${m.t}" x2="${meanX}" y2="${m.t + ph}" stroke="#0f62fe" stroke-width="1.5" stroke-dasharray="4 3"/>` +
+                `<text x="${meanX}" y="${m.t + 12}" text-anchor="middle" font-size="11" font-weight="700" fill="#0f62fe">μ = ${fmt(src.mean, 2)}</text>`;
 
             // SE bracket: μ ± 2·SE around the predicted normal
             const lo = src.mean - 2 * se;
             const hi = src.mean + 2 * se;
             const yBracket = m.t + ph + 22;
             const seBracket =
-                `<line x1="${xS(lo)}" y1="${yBracket}" x2="${xS(hi)}" y2="${yBracket}" stroke="#dc2626" stroke-width="2"/>` +
-                `<line x1="${xS(lo)}" y1="${yBracket - 4}" x2="${xS(lo)}" y2="${yBracket + 4}" stroke="#dc2626" stroke-width="2"/>` +
-                `<line x1="${xS(hi)}" y1="${yBracket - 4}" x2="${xS(hi)}" y2="${yBracket + 4}" stroke="#dc2626" stroke-width="2"/>` +
+                `<line x1="${xS(lo)}" y1="${yBracket}" x2="${xS(hi)}" y2="${yBracket}" stroke="#da1e28" stroke-width="2"/>` +
+                `<line x1="${xS(lo)}" y1="${yBracket - 4}" x2="${xS(lo)}" y2="${yBracket + 4}" stroke="#da1e28" stroke-width="2"/>` +
+                `<line x1="${xS(hi)}" y1="${yBracket - 4}" x2="${xS(hi)}" y2="${yBracket + 4}" stroke="#da1e28" stroke-width="2"/>` +
                 `<text x="${xS(src.mean)}" y="${yBracket - 6}" text-anchor="middle" font-size="10" fill="#991b1b">μ ± 2·σ/√n</text>`;
 
             // Frame & ticks
-            const frame = `<rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e5e7eb"/>`;
+            const frame = `<rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e0e0e0"/>`;
             const ticks = xTicks(xmin, xmax, xS, m.t + ph, m, pw);
-            const xLabel = `<text x="${m.l + pw / 2}" y="${h - 4}" text-anchor="middle" font-size="12" fill="#4b5563">sample mean (average of n draws)</text>`;
+            const xLabel = `<text x="${m.l + pw / 2}" y="${h - 4}" text-anchor="middle" font-size="12" fill="#525252">sample mean (average of n draws)</text>`;
 
-            const theoCurve = `<path d="${curvePath}" fill="none" stroke="#dc2626" stroke-width="2.2" stroke-dasharray="6 4"/>`;
+            const theoCurve = `<path d="${curvePath}" fill="none" stroke="#da1e28" stroke-width="2.2" stroke-dasharray="6 4"/>`;
 
             els.meanChart.innerHTML = frame + bars + theoCurve + meanLine + seBracket + ticks + xLabel;
         }

--- a/math/equations.html
+++ b/math/equations.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -23,14 +23,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -39,7 +39,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 28px;
         }
@@ -48,7 +48,7 @@
             display: flex;
             gap: 8px;
             margin-bottom: 24px;
-            border-bottom: 2px solid #e5e7eb;
+            border-bottom: 2px solid #e0e0e0;
             padding-bottom: 0;
         }
 
@@ -59,18 +59,18 @@
             cursor: pointer;
             font-size: 14px;
             font-weight: 600;
-            color: #6b7280;
+            color: #525252;
             border-bottom: 3px solid transparent;
             margin-bottom: -2px;
-            border-radius: 4px 4px 0 0;
+            border-radius: 0;
             transition: color 0.15s, border-color 0.15s;
         }
 
-        .tab:hover { color: #1e3a8a; }
+        .tab:hover { color: #0f62fe; }
 
         .tab.active {
-            color: #1e3a8a;
-            border-bottom-color: #3b82f6;
+            color: #0f62fe;
+            border-bottom-color: #0f62fe;
         }
 
         .section { display: none; }
@@ -101,7 +101,7 @@
         }
 
         .control-group label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
             display: flex;
@@ -109,7 +109,7 @@
         }
 
         .control-group label span {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             min-width: 40px;
             text-align: right;
@@ -117,14 +117,14 @@
 
         input[type="range"] {
             width: 100%;
-            accent-color: #3b82f6;
+            accent-color: #0f62fe;
             cursor: pointer;
         }
 
         .formula-box {
-            background: #eff6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 14px 18px;
             margin-bottom: 18px;
             text-align: center;
@@ -133,7 +133,7 @@
         .formula-box .formula {
             font-size: 22px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-family: 'Courier New', monospace;
             letter-spacing: 1px;
         }
@@ -147,45 +147,45 @@
 
         .result-card {
             background: #f0f4ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 12px 8px;
             text-align: center;
         }
 
         .result-card .label {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-bottom: 4px;
         }
 
         .result-card .value {
             font-size: 17px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
         }
 
         .explanation {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 16px 18px;
         }
 
         .explanation h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
             margin: 0 0 10px;
         }
 
         .explanation p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 6px 0;
             line-height: 1.6;
         }
 
-        .explanation strong { color: #374151; }
+        .explanation strong { color: #161616; }
 
         /* Solver styles */
         .solver-grid {
@@ -196,14 +196,14 @@
         }
 
         .solver-block {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 16px;
         }
 
         .solver-block h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 14px;
             margin: 0 0 12px;
         }
@@ -215,29 +215,29 @@
             margin-bottom: 10px;
             font-size: 15px;
             font-family: 'Courier New', monospace;
-            color: #374151;
+            color: #161616;
             flex-wrap: wrap;
         }
 
         .input-row input[type="number"] {
             width: 54px;
             padding: 5px 6px;
-            border: 1px solid #d1d5db;
-            border-radius: 6px;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
             font-size: 14px;
             font-family: 'Courier New', monospace;
             text-align: center;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
         }
 
         .solve-btn {
             width: 100%;
             padding: 9px;
-            background: #3b82f6;
+            background: #0f62fe;
             color: white;
             border: none;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -245,12 +245,12 @@
             margin-top: 6px;
         }
 
-        .solve-btn:hover { background: #2563eb; }
+        .solve-btn:hover { background: #0043ce; }
 
         .answer-box {
             margin-top: 10px;
             padding: 10px 14px;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 15px;
             font-weight: 600;
             text-align: center;
@@ -260,7 +260,7 @@
 
         .answer-ok { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
         .answer-err { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
-        .answer-empty { background: #f3f4f6; color: #9ca3af; border: 1px solid #e5e7eb; }
+        .answer-empty { background: #f4f4f4; color: #8c8c8c; border: 1px solid #e0e0e0; }
 
         @media (max-width: 600px) {
             .container { padding: 18px; }
@@ -281,13 +281,14 @@
             .result-card { padding: 9px 5px; }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -466,13 +467,13 @@
     // ── Linear chart ──────────────────────────────────────────────────────────
     const linearChart = new Chart(document.getElementById('linearChart').getContext('2d'), {
         type: 'line',
-        data: { datasets: [{ label: 'y = mx + b', data: [], borderColor: '#3b82f6', borderWidth: 2.5, pointRadius: 0, fill: false, tension: 0 }] },
+        data: { datasets: [{ label: 'y = mx + b', data: [], borderColor: '#0f62fe', borderWidth: 2.5, pointRadius: 0, fill: false, tension: 0 }] },
         options: {
             responsive: true, maintainAspectRatio: false, parsing: false,
             plugins: { legend: { display: false }, tooltip: { callbacks: { label: c => `y = ${fmt(c.parsed.y)}` } } },
             scales: {
-                x: { type: 'linear', min: -10, max: 10, title: { display: true, text: 'x', color: '#6b7280' }, grid: { color: '#f3f4f6' } },
-                y: { min: -15, max: 15, title: { display: true, text: 'y', color: '#6b7280' }, grid: { color: '#f3f4f6' } }
+                x: { type: 'linear', min: -10, max: 10, title: { display: true, text: 'x', color: '#525252' }, grid: { color: '#f4f4f4' } },
+                y: { min: -15, max: 15, title: { display: true, text: 'y', color: '#525252' }, grid: { color: '#f4f4f4' } }
             }
         }
     });
@@ -504,13 +505,13 @@
     // ── Quadratic chart ───────────────────────────────────────────────────────
     const quadChart = new Chart(document.getElementById('quadChart').getContext('2d'), {
         type: 'line',
-        data: { datasets: [{ label: 'y = ax²+bx+c', data: [], borderColor: '#3b82f6', borderWidth: 2.5, pointRadius: 0, fill: false, tension: 0 }] },
+        data: { datasets: [{ label: 'y = ax²+bx+c', data: [], borderColor: '#0f62fe', borderWidth: 2.5, pointRadius: 0, fill: false, tension: 0 }] },
         options: {
             responsive: true, maintainAspectRatio: false, parsing: false,
             plugins: { legend: { display: false }, tooltip: { callbacks: { label: c => `y = ${fmt(c.parsed.y)}` } } },
             scales: {
-                x: { type: 'linear', min: -8, max: 8, title: { display: true, text: 'x', color: '#6b7280' }, grid: { color: '#f3f4f6' } },
-                y: { min: -15, max: 20, title: { display: true, text: 'y', color: '#6b7280' }, grid: { color: '#f3f4f6' } }
+                x: { type: 'linear', min: -8, max: 8, title: { display: true, text: 'x', color: '#525252' }, grid: { color: '#f4f4f4' } },
+                y: { min: -15, max: 20, title: { display: true, text: 'y', color: '#525252' }, grid: { color: '#f4f4f4' } }
             }
         }
     });

--- a/math/exponential.html
+++ b/math/exponential.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -23,14 +23,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -39,7 +39,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 24px;
         }
@@ -65,7 +65,7 @@
         }
 
         .control-group label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
             display: flex;
@@ -73,7 +73,7 @@
         }
 
         .control-group label span {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             min-width: 40px;
             text-align: right;
@@ -81,14 +81,14 @@
 
         input[type="range"] {
             width: 100%;
-            accent-color: #3b82f6;
+            accent-color: #0f62fe;
             cursor: pointer;
         }
 
         .formula-box {
-            background: #eff6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 14px 18px;
             margin-bottom: 20px;
             text-align: center;
@@ -97,14 +97,14 @@
         .formula-box .formula {
             font-size: 20px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-family: 'Courier New', monospace;
             letter-spacing: 1px;
         }
 
         .formula-box .hint {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-top: 4px;
         }
 
@@ -117,28 +117,28 @@
 
         .result-card {
             background: #f0f4ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 14px 10px;
             text-align: center;
         }
 
         .result-card .label {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-bottom: 4px;
         }
 
         .result-card .value {
             font-size: 18px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
         }
 
         .badge {
             display: inline-block;
             padding: 4px 14px;
-            border-radius: 20px;
+            border-radius: 0;
             font-size: 13px;
             font-weight: 600;
             margin-bottom: 16px;
@@ -160,33 +160,33 @@
         }
 
         .badge-neutral {
-            background: #f3f4f6;
-            color: #6b7280;
-            border: 1px solid #e5e7eb;
+            background: #f4f4f4;
+            color: #525252;
+            border: 1px solid #e0e0e0;
         }
 
         .explanation {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 16px 18px;
         }
 
         .explanation h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
             margin: 0 0 10px;
         }
 
         .explanation p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 6px 0;
             line-height: 1.6;
         }
 
         .explanation strong {
-            color: #374151;
+            color: #161616;
         }
 
         @media (max-width: 600px) {
@@ -206,13 +206,14 @@
             .result-card .label { font-size: 11px; }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -342,7 +343,7 @@
                 datasets: [{
                     label: 'y = a·eᵇˣ',
                     data: [],
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     borderWidth: 2.5,
                     pointRadius: 0,
                     fill: false,
@@ -364,12 +365,12 @@
                 scales: {
                     x: {
                         type: 'linear',
-                        title: { display: true, text: 'x', color: '#6b7280' },
-                        grid: { color: '#f3f4f6' }
+                        title: { display: true, text: 'x', color: '#525252' },
+                        grid: { color: '#f4f4f4' }
                     },
                     y: {
-                        title: { display: true, text: 'y', color: '#6b7280' },
-                        grid: { color: '#f3f4f6' }
+                        title: { display: true, text: 'y', color: '#525252' },
+                        grid: { color: '#f4f4f4' }
                     }
                 }
             }

--- a/math/linear_regression.html
+++ b/math/linear_regression.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -23,14 +23,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -39,7 +39,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 24px;
         }
@@ -61,7 +61,7 @@
         }
 
         .add-point label {
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
             white-space: nowrap;
@@ -70,22 +70,22 @@
         .add-point input {
             width: 80px;
             padding: 7px 10px;
-            border: 1px solid #d1d5db;
-            border-radius: 8px;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
             font-size: 14px;
             transition: border-color 0.2s, box-shadow 0.2s;
         }
 
         .add-point input:focus {
             outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.4);
+            border-color: #0f62fe;
+            box-shadow: none;
         }
 
         .btn {
             padding: 8px 16px;
             border: none;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -93,22 +93,22 @@
         }
 
         .btn-primary {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         .btn-primary:hover {
-            background: #1e40af;
+            background: #0050e6;
             transform: translateY(-1px);
         }
 
         .btn-danger {
-            background: #9ca3af;
+            background: #8c8c8c;
             color: white;
         }
 
         .btn-danger:hover {
-            background: #6b7280;
+            background: #525252;
             transform: translateY(-1px);
         }
 
@@ -121,28 +121,28 @@
 
         .result-card {
             background: #f0f4ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 14px 10px;
             text-align: center;
         }
 
         .result-card .label {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-bottom: 4px;
         }
 
         .result-card .value {
             font-size: 20px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
         }
 
         .formula-box {
-            background: #eff6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
             padding: 14px 18px;
             margin-bottom: 20px;
             text-align: center;
@@ -151,50 +151,50 @@
         .formula-box .formula {
             font-size: 18px;
             font-weight: 600;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-family: 'Courier New', monospace;
             letter-spacing: 1px;
         }
 
         .formula-box .hint {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-top: 4px;
         }
 
         .explanation {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 16px 18px;
         }
 
         .explanation h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
             margin: 0 0 10px;
         }
 
         .explanation p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 6px 0;
             line-height: 1.6;
         }
 
         .explanation strong {
-            color: #374151;
+            color: #161616;
         }
 
         .point-hint {
             font-size: 12px;
-            color: #9ca3af;
+            color: #8c8c8c;
             text-align: center;
             margin-bottom: 10px;
         }
 
         #error {
-            color: #dc2626;
+            color: #da1e28;
             font-size: 13px;
             margin-bottom: 8px;
             display: none;
@@ -255,13 +255,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -402,7 +403,7 @@
                     {
                         label: 'Data points',
                         data: [],
-                        backgroundColor: '#3b82f6',
+                        backgroundColor: '#0f62fe',
                         pointRadius: 6,
                         pointHoverRadius: 8,
                     },
@@ -410,7 +411,7 @@
                         label: 'Regression line',
                         data: [],
                         type: 'line',
-                        borderColor: '#1e3a8a',
+                        borderColor: '#0f62fe',
                         borderWidth: 2,
                         pointRadius: 0,
                         fill: false,
@@ -430,8 +431,8 @@
                     }
                 },
                 scales: {
-                    x: { title: { display: true, text: 'x', color: '#6b7280' }, grid: { color: '#f3f4f6' } },
-                    y: { title: { display: true, text: 'y', color: '#6b7280' }, grid: { color: '#f3f4f6' } }
+                    x: { title: { display: true, text: 'x', color: '#525252' }, grid: { color: '#f4f4f4' } },
+                    y: { title: { display: true, text: 'y', color: '#525252' }, grid: { color: '#f4f4f4' } }
                 },
                 onClick(event, elements, chart) {
                     const canvasPos = Chart.helpers.getRelativePosition(event, chart);

--- a/math/p_value.html
+++ b/math/p_value.html
@@ -6,8 +6,8 @@
     <title>P-Value &amp; Confidence Interval</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,14 +22,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -38,13 +38,13 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 22px;
         }
 
         h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin: 24px 0 10px;
         }
@@ -60,10 +60,10 @@
             flex: 1 1 auto;
             min-width: 140px;
             padding: 10px 12px;
-            border: 1px solid #dbeafe;
-            background: #eff6ff;
-            color: #1e3a8a;
-            border-radius: 8px;
+            border: 1px solid #edf5ff;
+            background: #f4f4f4;
+            color: #0f62fe;
+            border-radius: 0;
             font-size: 13px;
             font-weight: 600;
             cursor: pointer;
@@ -71,14 +71,14 @@
         }
 
         .scenarios button:hover {
-            background: #dbeafe;
+            background: #edf5ff;
             transform: translateY(-1px);
         }
 
         .scenarios button.active {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
-            border-color: #1e3a8a;
+            border-color: #0f62fe;
         }
 
         .controls {
@@ -101,28 +101,28 @@
         }
 
         .control-row label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
         }
 
         .control-row .value {
-            color: #1f2937;
+            color: #161616;
             font-size: 13px;
             font-variant-numeric: tabular-nums;
         }
 
         .control-row input[type="range"] {
             width: 100%;
-            accent-color: #1e3a8a;
+            accent-color: #0f62fe;
         }
 
         .toggle {
             display: inline-flex;
-            background: #f3f4f6;
-            border-radius: 8px;
+            background: #f4f4f4;
+            border-radius: 0;
             padding: 3px;
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
         }
 
         .toggle button {
@@ -131,33 +131,33 @@
             padding: 6px 12px;
             font-size: 13px;
             font-weight: 600;
-            color: #6b7280;
-            border-radius: 6px;
+            color: #525252;
+            border-radius: 0;
             cursor: pointer;
         }
 
         .toggle button.active {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         .chart-wrap {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 14px 12px 8px;
             margin-bottom: 14px;
         }
 
         .chart-title {
-            color: #374151;
+            color: #161616;
             font-size: 13px;
             font-weight: 600;
             margin: 0 4px 6px;
         }
 
         .chart-note {
-            color: #6b7280;
+            color: #525252;
             font-size: 12px;
             margin: 4px 4px 0;
         }
@@ -176,14 +176,14 @@
         }
 
         .stat {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 10px 12px;
         }
 
         .stat .label {
-            color: #6b7280;
+            color: #525252;
             font-size: 11px;
             text-transform: uppercase;
             letter-spacing: 0.5px;
@@ -191,7 +191,7 @@
         }
 
         .stat .num {
-            color: #1f2937;
+            color: #161616;
             font-size: 20px;
             font-weight: 700;
             font-variant-numeric: tabular-nums;
@@ -201,7 +201,7 @@
         .verdict {
             margin-top: 14px;
             padding: 14px 16px;
-            border-radius: 10px;
+            border-radius: 0;
             border-left: 4px solid;
             font-size: 14px;
             line-height: 1.5;
@@ -209,13 +209,13 @@
 
         .verdict.sig {
             background: #ecfdf5;
-            border-color: #10b981;
+            border-color: #24a148;
             color: #065f46;
         }
 
         .verdict.notsig {
             background: #fffbeb;
-            border-color: #f59e0b;
+            border-color: #f1c21b;
             color: #78350f;
         }
 
@@ -228,20 +228,20 @@
         .abstract-line {
             margin-top: 10px;
             font-style: italic;
-            color: #374151;
+            color: #161616;
             font-size: 13px;
         }
 
         .explainer {
             margin-top: 26px;
             padding: 18px 20px;
-            background: #eff6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
         }
 
         .explainer p {
-            color: #374151;
+            color: #161616;
             font-size: 13.5px;
             line-height: 1.55;
             margin: 0 0 10px;
@@ -252,22 +252,22 @@
         }
 
         .explainer code {
-            background: #dbeafe;
-            color: #1e3a8a;
+            background: #edf5ff;
+            color: #0f62fe;
             padding: 1px 6px;
-            border-radius: 4px;
+            border-radius: 0;
             font-size: 12.5px;
         }
 
         .explainer .tag {
             display: inline-block;
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
             font-size: 11px;
             font-weight: 700;
             letter-spacing: 0.5px;
             padding: 2px 8px;
-            border-radius: 4px;
+            border-radius: 0;
             margin-right: 6px;
             vertical-align: 1px;
         }
@@ -278,13 +278,14 @@
             .container { padding: 18px; }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -500,8 +501,8 @@
             const ticks = [-4, -3, -2, -1, 0, 1, 2, 3, 4];
             const tickEls = ticks.map(t => {
                 const x = xS(t);
-                return `<line x1="${x}" y1="${m.t + ph}" x2="${x}" y2="${m.t + ph + 4}" stroke="#9ca3af" stroke-width="1"/>` +
-                       `<text x="${x}" y="${m.t + ph + 16}" text-anchor="middle" font-size="11" fill="#6b7280">${t}</text>`;
+                return `<line x1="${x}" y1="${m.t + ph}" x2="${x}" y2="${m.t + ph + 4}" stroke="#8c8c8c" stroke-width="1"/>` +
+                       `<text x="${x}" y="${m.t + ph + 16}" text-anchor="middle" font-size="11" fill="#525252">${t}</text>`;
             }).join('');
 
             // Observed line
@@ -511,15 +512,15 @@
             const labelAnchor = z >= 0 ? 'start' : 'end';
 
             const svg = `
-                <rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e5e7eb"/>
+                <rect x="${m.l}" y="${m.t}" width="${pw}" height="${ph}" fill="white" stroke="#e0e0e0"/>
                 <path d="${rightTail}" fill="#fca5a5" fill-opacity="0.7" stroke="none"/>
                 <path d="${leftTail}"  fill="#fca5a5" fill-opacity="0.7" stroke="none"/>
-                <path d="${curvePath}" fill="none" stroke="#1e3a8a" stroke-width="2"/>
-                <line x1="${xS(0)}" y1="${m.t}" x2="${xS(0)}" y2="${m.t + ph}" stroke="#9ca3af" stroke-width="1" stroke-dasharray="3 3"/>
-                <line x1="${obsX}" y1="${m.t}" x2="${obsX}" y2="${m.t + ph}" stroke="#dc2626" stroke-width="2"/>
-                <text x="${labelX}" y="${m.t + 14}" text-anchor="${labelAnchor}" font-size="12" font-weight="700" fill="#dc2626">${obsLabel}</text>
+                <path d="${curvePath}" fill="none" stroke="#0f62fe" stroke-width="2"/>
+                <line x1="${xS(0)}" y1="${m.t}" x2="${xS(0)}" y2="${m.t + ph}" stroke="#8c8c8c" stroke-width="1" stroke-dasharray="3 3"/>
+                <line x1="${obsX}" y1="${m.t}" x2="${obsX}" y2="${m.t + ph}" stroke="#da1e28" stroke-width="2"/>
+                <text x="${labelX}" y="${m.t + 14}" text-anchor="${labelAnchor}" font-size="12" font-weight="700" fill="#da1e28">${obsLabel}</text>
                 ${tickEls}
-                <text x="${m.l + pw/2}" y="${h - 6}" text-anchor="middle" font-size="12" fill="#4b5563">standardized difference (z)</text>
+                <text x="${m.l + pw/2}" y="${h - 6}" text-anchor="middle" font-size="12" fill="#525252">standardized difference (z)</text>
                 <text x="${m.l + pw - 6}" y="${m.t + 16}" text-anchor="end" font-size="11" fill="#991b1b">tails area = ${fmtP(p).replace('p ', '')}</text>
             `;
             els.nullChart.innerHTML = svg;
@@ -543,7 +544,7 @@
             const xS = v => m.l + (v - lo) / (hi - lo) * pw;
 
             const crossesZero = ciLow <= 0 && ciHigh >= 0;
-            const barColor = crossesZero ? '#f59e0b' : '#10b981';
+            const barColor = crossesZero ? '#f1c21b' : '#24a148';
             const barFill  = crossesZero ? '#fde68a' : '#a7f3d0';
 
             // Nice tick step
@@ -566,8 +567,8 @@
             const tickEls = ticks.map(t => {
                 const x = xS(t);
                 const isZero = Math.abs(t) < 1e-9;
-                return `<line x1="${x}" y1="${cy + 14}" x2="${x}" y2="${cy + 18}" stroke="#9ca3af"/>` +
-                       `<text x="${x}" y="${cy + 30}" text-anchor="middle" font-size="11" fill="${isZero ? '#dc2626' : '#6b7280'}" font-weight="${isZero ? '700' : '400'}">${(+t.toFixed(6)).toString()}</text>`;
+                return `<line x1="${x}" y1="${cy + 14}" x2="${x}" y2="${cy + 18}" stroke="#8c8c8c"/>` +
+                       `<text x="${x}" y="${cy + 30}" text-anchor="middle" font-size="11" fill="${isZero ? '#da1e28' : '#525252'}" font-weight="${isZero ? '700' : '400'}">${(+t.toFixed(6)).toString()}</text>`;
             }).join('');
 
             const x0 = xS(0);
@@ -576,15 +577,15 @@
             const xEst = xS(diff);
 
             const svg = `
-                <line x1="${m.l}" y1="${cy + 14}" x2="${m.l + pw}" y2="${cy + 14}" stroke="#9ca3af"/>
-                <line x1="${x0}" y1="${m.t - 4}" x2="${x0}" y2="${cy + 14}" stroke="#dc2626" stroke-width="2" stroke-dasharray="4 3"/>
-                <text x="${x0}" y="${m.t - 8}" text-anchor="middle" font-size="11" font-weight="700" fill="#dc2626">no effect (0)</text>
+                <line x1="${m.l}" y1="${cy + 14}" x2="${m.l + pw}" y2="${cy + 14}" stroke="#8c8c8c"/>
+                <line x1="${x0}" y1="${m.t - 4}" x2="${x0}" y2="${cy + 14}" stroke="#da1e28" stroke-width="2" stroke-dasharray="4 3"/>
+                <text x="${x0}" y="${m.t - 8}" text-anchor="middle" font-size="11" font-weight="700" fill="#da1e28">no effect (0)</text>
                 <rect x="${xLow}" y="${cy - 10}" width="${Math.max(2, xHigh - xLow)}" height="20" rx="3" fill="${barFill}" stroke="${barColor}" stroke-width="2"/>
                 <line x1="${xLow}" y1="${cy - 14}" x2="${xLow}" y2="${cy + 14}" stroke="${barColor}" stroke-width="2"/>
                 <line x1="${xHigh}" y1="${cy - 14}" x2="${xHigh}" y2="${cy + 14}" stroke="${barColor}" stroke-width="2"/>
                 <circle cx="${xEst}" cy="${cy}" r="5" fill="${barColor}" stroke="white" stroke-width="2"/>
                 ${tickEls}
-                <text x="${m.l + pw / 2}" y="${h - 4}" text-anchor="middle" font-size="12" fill="#4b5563">effect size (treatment − control)</text>
+                <text x="${m.l + pw / 2}" y="${h - 4}" text-anchor="middle" font-size="12" fill="#525252">effect size (treatment − control)</text>
             `;
             els.ciChart.innerHTML = svg;
         }

--- a/math/polish.html
+++ b/math/polish.html
@@ -6,8 +6,8 @@
     <title>Reverse Polish Notation Calculator</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,14 +22,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 24px;
@@ -46,7 +46,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
             min-width: 120px;
@@ -55,8 +55,8 @@
         input {
             width: 100px;
             padding: 8px 12px;
-            border: 1px solid #d1d5db;
-            border-radius: 8px;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
             font-size: 14px;
             transition: border-color 0.3s ease, box-shadow 0.3s ease;
             flex-grow: 1;
@@ -65,8 +65,8 @@
 
         input:focus {
             outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+            border-color: #0f62fe;
+            box-shadow: none;
         }
 
         .button-group {
@@ -80,7 +80,7 @@
         button {
             padding: 10px 20px;
             border: none;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -89,32 +89,32 @@
         }
 
         #enterBtn {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         #enterBtn:hover {
-            background: #1e40af;
+            background: #0050e6;
             transform: translateY(-2px);
         }
 
         #clearBtn {
-            background: #9ca3af;
+            background: #8c8c8c;
             color: white;
         }
 
         #clearBtn:hover {
-            background: #6b7280;
+            background: #525252;
             transform: translateY(-2px);
         }
 
         #stackDisplay {
             margin-top: 25px;
             padding: 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
-            color: #374151;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
+            color: #161616;
             font-size: 14px;
             min-height: 50px;
         }
@@ -128,31 +128,31 @@
 
         #stackDisplay span {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         .instructions {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .instructions h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .instructions p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
 
         #error {
-            color: #dc2626;
+            color: #da1e28;
             font-size: 13px;
             margin-top: 10px;
             display: none;
@@ -265,13 +265,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">

--- a/math/risk.html
+++ b/math/risk.html
@@ -6,8 +6,8 @@
     <title>Risk, NNT, and Efficacy Calculator</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -19,14 +19,14 @@
             width: 520px;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             margin: 30px 0;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 24px;
@@ -41,7 +41,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
         }
@@ -49,16 +49,16 @@
         input {
             width: 100px;
             padding: 8px 12px;
-            border: 1px solid #d1d5db;
-            border-radius: 8px;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
             font-size: 14px;
             transition: border-color 0.3s ease, box-shadow 0.3s ease;
         }
 
         input:focus {
             outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+            border-color: #0f62fe;
+            box-shadow: none;
         }
 
         .value-container {
@@ -70,7 +70,7 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -78,36 +78,36 @@
         }
 
         .up-btn {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         .up-btn:hover {
-            background: #1e40af;
+            background: #0050e6;
             transform: translateY(-2px);
         }
 
         .down-btn {
-            background: #9ca3af;
+            background: #8c8c8c;
             color: white;
         }
 
         .down-btn:hover {
-            background: #6b7280;
+            background: #525252;
             transform: translateY(-2px);
         }
 
         #results, #harmBenefit {
             margin-top: 25px;
             padding: 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         #results p, #harmBenefit p {
             margin: 10px 0;
-            color: #374151;
+            color: #161616;
             font-size: 14px;
             display: flex;
             justify-content: space-between;
@@ -116,15 +116,15 @@
 
         #results span, #harmBenefit span {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
             text-align: right;
         }
 
         .subhead {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
             margin: 22px 0 8px;
-            border-bottom: 1px solid #e5e7eb;
+            border-bottom: 1px solid #e0e0e0;
             padding-bottom: 6px;
         }
 
@@ -136,31 +136,31 @@
             display: block !important;
             margin-top: 14px !important;
             padding: 12px 14px;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 13px;
             line-height: 1.5;
-            border-left: 4px solid #9ca3af;
-            background: #f3f4f6;
-            color: #1f2937;
+            border-left: 4px solid #8c8c8c;
+            background: #f4f4f4;
+            color: #161616;
         }
 
         .conclusion.favorable {
             background: #ecfdf5;
-            border-left-color: #10b981;
+            border-left-color: #24a148;
         }
 
         .conclusion.mixed {
             background: #fffbeb;
-            border-left-color: #f59e0b;
+            border-left-color: #f1c21b;
         }
 
         .conclusion.unfavorable {
             background: #fef2f2;
-            border-left-color: #ef4444;
+            border-left-color: #da1e28;
         }
 
         #error {
-            color: #dc2626;
+            color: #da1e28;
             font-size: 13px;
             margin-top: 10px;
             display: none;
@@ -170,19 +170,19 @@
         .instructions {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .instructions h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .instructions p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
@@ -194,13 +194,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">

--- a/math/simpsons_paradox.html
+++ b/math/simpsons_paradox.html
@@ -6,8 +6,8 @@
     <title>Simpson's Paradox</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,14 +22,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -38,7 +38,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 22px;
         }
@@ -58,7 +58,7 @@
         }
 
         .control-row label.lead {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
             white-space: nowrap;
@@ -66,10 +66,10 @@
 
         .toggle-buttons {
             display: inline-flex;
-            background: #f3f4f6;
-            border-radius: 9px;
+            background: #f4f4f4;
+            border-radius: 0;
             padding: 3px;
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
         }
 
         .toggle-buttons button {
@@ -78,20 +78,20 @@
             padding: 7px 14px;
             font-size: 13px;
             font-weight: 600;
-            color: #6b7280;
+            color: #525252;
             cursor: pointer;
-            border-radius: 6px;
+            border-radius: 0;
             transition: background-color 0.15s, color 0.15s, box-shadow 0.15s;
         }
 
         .toggle-buttons button:hover {
-            color: #1e3a8a;
+            color: #0f62fe;
         }
 
         .toggle-buttons button.active {
             background: #ffffff;
-            color: #1e3a8a;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+            color: #0f62fe;
+            box-shadow: none;
         }
 
         .slider-wrap {
@@ -109,7 +109,7 @@
             appearance: none;
             height: 6px;
             background: linear-gradient(90deg, #c7d2fe, #818cf8);
-            border-radius: 3px;
+            border-radius: 0;
             outline: none;
         }
 
@@ -118,11 +118,11 @@
             appearance: none;
             width: 18px;
             height: 18px;
-            border-radius: 50%;
-            background: #1e3a8a;
+            border-radius: 0;
+            background: #0f62fe;
             cursor: pointer;
             border: 2px solid #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+            box-shadow: none;
             transition: transform 0.15s;
         }
 
@@ -133,17 +133,17 @@
         input[type="range"]::-moz-range-thumb {
             width: 18px;
             height: 18px;
-            border-radius: 50%;
-            background: #1e3a8a;
+            border-radius: 0;
+            background: #0f62fe;
             cursor: pointer;
             border: 2px solid #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+            box-shadow: none;
         }
 
         .slider-value {
             font-size: 13px;
             font-weight: 600;
-            color: #1e3a8a;
+            color: #0f62fe;
             min-width: 44px;
             text-align: right;
             font-variant-numeric: tabular-nums;
@@ -152,7 +152,7 @@
         .chart-wrap {
             width: 100%;
             margin-bottom: 16px;
-            border-radius: 10px;
+            border-radius: 0;
             overflow: hidden;
         }
 
@@ -186,9 +186,9 @@
         }
 
         .legend-card {
-            background: #f9fafb;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 0;
             padding: 10px 8px;
             text-align: center;
             transition: opacity 0.25s ease;
@@ -200,7 +200,7 @@
             justify-content: center;
             gap: 6px;
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-bottom: 4px;
             font-weight: 600;
         }
@@ -208,27 +208,27 @@
         .legend-card .dot {
             width: 10px;
             height: 10px;
-            border-radius: 50%;
+            border-radius: 0;
             display: inline-block;
         }
 
         .legend-card .dash {
             width: 16px;
             height: 3px;
-            border-radius: 2px;
+            border-radius: 0;
             display: inline-block;
         }
 
         .legend-card .slope {
             font-size: 18px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-variant-numeric: tabular-nums;
         }
 
         .legend-card.overall {
-            background: #eff6ff;
-            border-color: #dbeafe;
+            background: #f4f4f4;
+            border-color: #edf5ff;
         }
 
         .legend-card.dim {
@@ -236,31 +236,31 @@
         }
 
         .explanation {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 16px 18px;
         }
 
         .explanation h3 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
             margin: 0 0 10px;
         }
 
         .explanation p {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 6px 0;
             line-height: 1.6;
         }
 
         .explanation strong {
-            color: #374151;
+            color: #161616;
         }
 
         .explanation em {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-style: normal;
             font-weight: 600;
         }
@@ -294,13 +294,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -361,15 +362,15 @@
                 <g id="grid"></g>
                 <g id="axes"></g>
 
-                <line x1="60" y1="400" x2="670" y2="400" stroke="#9ca3af" stroke-width="1.2"/>
-                <line x1="60" y1="30" x2="60" y2="400" stroke="#9ca3af" stroke-width="1.2"/>
+                <line x1="60" y1="400" x2="670" y2="400" stroke="#8c8c8c" stroke-width="1.2"/>
+                <line x1="60" y1="30" x2="60" y2="400" stroke="#8c8c8c" stroke-width="1.2"/>
 
                 <g id="overallLine"></g>
                 <g id="groupLines"></g>
                 <g id="points" filter="url(#dotShadow)"></g>
 
                 <g id="tooltip" style="display:none; pointer-events:none">
-                    <rect class="tt-bg" rx="5" ry="5" width="92" height="40" fill="#1f2937" opacity="0.94"/>
+                    <rect class="tt-bg" rx="5" ry="5" width="92" height="40" fill="#161616" opacity="0.94"/>
                     <text class="tt-title" x="46" y="16" text-anchor="middle" fill="#fff" font-size="11" font-weight="700"></text>
                     <text class="tt-coord" x="46" y="31" text-anchor="middle" fill="#cbd5e1" font-size="10" font-variant-numeric="tabular-nums"></text>
                 </g>
@@ -382,7 +383,7 @@
                 <div class="slope" id="slopeA">—</div>
             </div>
             <div class="legend-card group-card" data-group="1">
-                <div class="key"><span class="dot" style="background:#10b981"></span> Group B</div>
+                <div class="key"><span class="dot" style="background:#24a148"></span> Group B</div>
                 <div class="slope" id="slopeB">—</div>
             </div>
             <div class="legend-card group-card" data-group="2">
@@ -390,7 +391,7 @@
                 <div class="slope" id="slopeC">—</div>
             </div>
             <div class="legend-card overall overall-card">
-                <div class="key"><span class="dash" style="background:#1e3a8a"></span> Overall</div>
+                <div class="key"><span class="dash" style="background:#0f62fe"></span> Overall</div>
                 <div class="slope" id="slopeAll">—</div>
             </div>
         </div>
@@ -431,7 +432,7 @@
                 { dx:  0.2, dy: -0.1 }, { dx:  0.5, dy: -0.4 },
                 { dx:  0.8, dy: -0.3 }, { dx:  1.0, dy: -0.6 }
               ] },
-            { name: 'B', color: '#10b981', baseCenter: { x: 5, y: 5.0 },
+            { name: 'B', color: '#24a148', baseCenter: { x: 5, y: 5.0 },
               offsets: [
                 { dx: -1.0, dy:  0.5 }, { dx: -0.7, dy:  0.4 },
                 { dx: -0.4, dy:  0.3 }, { dx: -0.1, dy:  0.0 },
@@ -488,14 +489,14 @@
             for (let x = xMin; x <= xMax; x++) {
                 grid.appendChild(el('line', {
                     x1: sx(x), y1: padT, x2: sx(x), y2: padT + plotH,
-                    stroke: x === 0 ? '#d1d5db' : '#e5e7eb',
+                    stroke: x === 0 ? '#c6c6c6' : '#e0e0e0',
                     'stroke-width': 1,
                     'stroke-dasharray': x === 0 ? '0' : '2 4'
                 }));
 
                 const tx = el('text', {
                     x: sx(x), y: padT + plotH + 20,
-                    'text-anchor': 'middle', fill: '#6b7280',
+                    'text-anchor': 'middle', fill: '#525252',
                     'font-size': 11, 'font-variant-numeric': 'tabular-nums'
                 });
                 tx.textContent = x;
@@ -505,14 +506,14 @@
             for (let y = yMin; y <= yMax; y++) {
                 grid.appendChild(el('line', {
                     x1: padL, y1: sy(y), x2: padL + plotW, y2: sy(y),
-                    stroke: y === 0 ? '#d1d5db' : '#e5e7eb',
+                    stroke: y === 0 ? '#c6c6c6' : '#e0e0e0',
                     'stroke-width': 1,
                     'stroke-dasharray': y === 0 ? '0' : '2 4'
                 }));
 
                 const ty = el('text', {
                     x: padL - 10, y: sy(y) + 4,
-                    'text-anchor': 'end', fill: '#6b7280',
+                    'text-anchor': 'end', fill: '#525252',
                     'font-size': 11, 'font-variant-numeric': 'tabular-nums'
                 });
                 ty.textContent = y;
@@ -521,7 +522,7 @@
 
             const xLabel = el('text', {
                 x: padL + plotW / 2, y: H - 18,
-                'text-anchor': 'middle', fill: '#374151',
+                'text-anchor': 'middle', fill: '#161616',
                 'font-size': 13, 'font-weight': 600,
                 'font-style': 'italic'
             });
@@ -530,7 +531,7 @@
 
             const yLabel = el('text', {
                 x: -(padT + plotH / 2), y: 20,
-                'text-anchor': 'middle', fill: '#374151',
+                'text-anchor': 'middle', fill: '#161616',
                 'font-size': 13, 'font-weight': 600,
                 'font-style': 'italic',
                 transform: 'rotate(-90)'
@@ -663,7 +664,7 @@
                     overallLineLayer.appendChild(el('line', {
                         x1: sx(seg[0].x), y1: sy(seg[0].y),
                         x2: sx(seg[1].x), y2: sy(seg[1].y),
-                        stroke: '#1e3a8a',
+                        stroke: '#0f62fe',
                         'stroke-width': 3,
                         'stroke-linecap': 'round',
                         'stroke-dasharray': '9 6',

--- a/math/sine_cosine.html
+++ b/math/sine_cosine.html
@@ -7,8 +7,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -23,14 +23,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -39,7 +39,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 24px;
         }
@@ -55,7 +55,7 @@
         canvas#unitCircle {
             width: 100%;
             aspect-ratio: 1;
-            border-radius: 10px;
+            border-radius: 0;
             display: block;
         }
 
@@ -78,18 +78,18 @@
 
         .angle-label {
             font-weight: 600;
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 15px;
         }
 
         .angle-display {
             font-size: 15px;
-            color: #374151;
+            color: #161616;
         }
 
         input[type="range"] {
             width: 100%;
-            accent-color: #3b82f6;
+            accent-color: #0f62fe;
             cursor: pointer;
         }
 
@@ -101,16 +101,16 @@
         }
 
         .value-card {
-            background: #f3f4f6;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border-radius: 0;
             padding: 14px 10px;
             text-align: center;
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
         }
 
         .value-card .label {
             font-size: 12px;
-            color: #6b7280;
+            color: #525252;
             margin-bottom: 4px;
         }
 
@@ -119,18 +119,18 @@
             font-weight: 700;
         }
 
-        .val.sin-color { color: #3b82f6; }
-        .val.cos-color { color: #f59e0b; }
-        .val.tan-color { color: #10b981; }
+        .val.sin-color { color: #0f62fe; }
+        .val.cos-color { color: #f1c21b; }
+        .val.tan-color { color: #24a148; }
 
         .explanation {
             margin-top: 24px;
             background: #f0f4ff;
-            border-left: 4px solid #3b82f6;
-            border-radius: 0 8px 8px 0;
+            border-left: 4px solid #0f62fe;
+            border-radius: 0;
             padding: 14px 16px;
             font-size: 14px;
-            color: #374151;
+            color: #161616;
             line-height: 1.6;
         }
 
@@ -149,30 +149,30 @@
             display: flex;
             align-items: center;
             gap: 6px;
-            color: #374151;
+            color: #161616;
         }
 
         .legend-dot {
             width: 12px;
             height: 12px;
-            border-radius: 50%;
+            border-radius: 0;
         }
 
         .animate-btn {
             display: block;
             margin: 0 auto 16px;
             padding: 8px 24px;
-            background: #3b82f6;
+            background: #0f62fe;
             color: white;
             border: none;
-            border-radius: 8px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
             transition: background 0.2s;
         }
 
-        .animate-btn:hover { background: #2563eb; }
+        .animate-btn:hover { background: #0043ce; }
 
         @media (max-width: 600px) {
             .main-layout {
@@ -189,13 +189,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -214,8 +215,8 @@
             </div>
             <div>
                 <div class="legend">
-                    <span class="legend-item"><span class="legend-dot" style="background:#3b82f6"></span>sin(θ)</span>
-                    <span class="legend-item"><span class="legend-dot" style="background:#f59e0b"></span>cos(θ)</span>
+                    <span class="legend-item"><span class="legend-dot" style="background:#0f62fe"></span>sin(θ)</span>
+                    <span class="legend-item"><span class="legend-dot" style="background:#f1c21b"></span>cos(θ)</span>
                 </div>
                 <div class="chart-wrap">
                     <canvas id="waveChart" aria-label="Sine and cosine wave chart"></canvas>
@@ -269,7 +270,7 @@
                     {
                         label: 'sin(θ)',
                         data: sinData,
-                        borderColor: '#3b82f6',
+                        borderColor: '#0f62fe',
                         backgroundColor: 'transparent',
                         borderWidth: 2,
                         pointRadius: 0,
@@ -278,7 +279,7 @@
                     {
                         label: 'cos(θ)',
                         data: cosData,
-                        borderColor: '#f59e0b',
+                        borderColor: '#f1c21b',
                         backgroundColor: 'transparent',
                         borderWidth: 2,
                         pointRadius: 0,
@@ -307,20 +308,20 @@
                         type: 'linear',
                         min: 0,
                         max: 360,
-                        title: { display: true, text: 'θ (degrees)', color: '#6b7280', font: { size: 12 } },
+                        title: { display: true, text: 'θ (degrees)', color: '#525252', font: { size: 12 } },
                         ticks: {
                             stepSize: 90,
                             callback: v => v + '°',
-                            color: '#6b7280',
+                            color: '#525252',
                             font: { size: 11 }
                         },
-                        grid: { color: '#e5e7eb' }
+                        grid: { color: '#e0e0e0' }
                     },
                     y: {
                         min: -1.2,
                         max: 1.2,
-                        ticks: { color: '#6b7280', font: { size: 11 }, stepSize: 0.5 },
-                        grid: { color: '#e5e7eb' }
+                        ticks: { color: '#525252', font: { size: 11 }, stepSize: 0.5 },
+                        grid: { color: '#e0e0e0' }
                     }
                 }
             }
@@ -344,7 +345,7 @@
             ctx2.fill();
 
             // axes
-            ctx2.strokeStyle = '#d1d5db';
+            ctx2.strokeStyle = '#c6c6c6';
             ctx2.lineWidth = 1;
             ctx2.beginPath();
             ctx2.moveTo(cx - R - 14, cy);
@@ -372,7 +373,7 @@
             ctx2.stroke();
 
             // cos line (horizontal, x-axis to point)
-            ctx2.strokeStyle = '#f59e0b';
+            ctx2.strokeStyle = '#f1c21b';
             ctx2.lineWidth = 2.5;
             ctx2.setLineDash([4, 3]);
             ctx2.beginPath();
@@ -382,7 +383,7 @@
             ctx2.setLineDash([]);
 
             // sin line (vertical, from point to x-axis)
-            ctx2.strokeStyle = '#3b82f6';
+            ctx2.strokeStyle = '#0f62fe';
             ctx2.lineWidth = 2.5;
             ctx2.setLineDash([4, 3]);
             ctx2.beginPath();
@@ -400,31 +401,31 @@
             ctx2.stroke();
 
             // point on circle
-            ctx2.fillStyle = '#1e3a8a';
+            ctx2.fillStyle = '#0f62fe';
             ctx2.beginPath();
             ctx2.arc(px, py, 5, 0, Math.PI * 2);
             ctx2.fill();
 
             // labels
-            ctx2.font = 'bold 11px Segoe UI, sans-serif';
-            ctx2.fillStyle = '#f59e0b';
+            ctx2.font = 'bold 11px IBM Plex Sans, sans-serif';
+            ctx2.fillStyle = '#f1c21b';
             const cosLabelX = (cx + px) / 2;
             ctx2.fillText('cos', cosLabelX - 10, py - 5);
 
-            ctx2.fillStyle = '#3b82f6';
+            ctx2.fillStyle = '#0f62fe';
             const sinLabelY = (cy + py) / 2;
             ctx2.fillText('sin', px + 5, sinLabelY);
 
             // θ label
             ctx2.fillStyle = '#7c3aed';
-            ctx2.font = 'bold 12px Segoe UI, sans-serif';
+            ctx2.font = 'bold 12px IBM Plex Sans, sans-serif';
             const thetaR = R * 0.28;
             const halfRad = rad / 2;
             ctx2.fillText('θ', cx + thetaR * Math.cos(halfRad) - 4, cy - thetaR * Math.sin(halfRad) + 4);
 
             // axis tick labels
-            ctx2.fillStyle = '#9ca3af';
-            ctx2.font = '10px Segoe UI, sans-serif';
+            ctx2.fillStyle = '#8c8c8c';
+            ctx2.font = '10px IBM Plex Sans, sans-serif';
             ctx2.fillText('1', cx + R + 2, cy - 3);
             ctx2.fillText('-1', cx - R - 16, cy - 3);
             ctx2.fillText('1', cx + 3, cy - R - 2);
@@ -440,8 +441,8 @@
                 { x: deg, y: c }
             ];
             waveChart.data.datasets[2].pointRadius = [5, 5];
-            waveChart.data.datasets[2].pointBackgroundColor = ['#3b82f6', '#f59e0b'];
-            waveChart.data.datasets[2].pointBorderColor = ['#1e40af', '#d97706'];
+            waveChart.data.datasets[2].pointBackgroundColor = ['#0f62fe', '#f1c21b'];
+            waveChart.data.datasets[2].pointBorderColor = ['#0050e6', '#d97706'];
             waveChart.data.datasets[2].pointBorderWidth = [2, 2];
             waveChart.data.datasets[2].showLine = false;
         }

--- a/physics/blackbody.html
+++ b/physics/blackbody.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -25,14 +25,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 22px;
@@ -49,7 +49,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
         }
@@ -57,8 +57,8 @@
         input[type="range"] {
             width: 140px;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
         }
@@ -67,17 +67,17 @@
             -webkit-appearance: none;
             width: 16px;
             height: 16px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 16px;
             height: 16px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
         }
 
@@ -90,17 +90,17 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
             transition: background-color 0.3s ease, transform 0.2s ease;
         }
 
         .arrow-btn.down {
-            background: #9ca3af;
+            background: #8c8c8c;
         }
 
         .arrow-btn:hover {
@@ -118,24 +118,24 @@
             flex: 1 1 auto;
             padding: 6px 8px;
             font-size: 12px;
-            border: 1px solid #dbeafe;
-            border-radius: 6px;
-            background: #eff6ff;
-            color: #1e3a8a;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
+            background: #f4f4f4;
+            color: #0f62fe;
             cursor: pointer;
         }
 
         .preset-row button:hover {
-            background: #dbeafe;
+            background: #edf5ff;
         }
 
         .results {
             margin-top: 20px;
             padding: 15px 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
-            color: #374151;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
+            color: #161616;
             font-size: 14px;
         }
 
@@ -147,7 +147,7 @@
 
         .results .row span:last-child {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         .swatch {
@@ -155,39 +155,40 @@
             width: 16px;
             height: 16px;
             vertical-align: middle;
-            border-radius: 3px;
+            border-radius: 0;
             margin-left: 6px;
-            border: 1px solid #d1d5db;
+            border: 1px solid #c6c6c6;
         }
 
         canvas {
             margin-top: 20px;
             padding: 15px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         .explanation {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .explanation h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .explanation p, .explanation ul {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="calculator">
@@ -307,7 +308,7 @@
                 datasets: [{
                     label: 'Spectral radiance',
                     data: wavelengths.map(l => ({ x: l, y: planck(l, 5778) })),
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59, 130, 246, 0.15)',
                     fill: true,
                     pointRadius: 0,
@@ -329,20 +330,20 @@
                         position: 'bottom',
                         min: 100,
                         max: 5000,
-                        title: { display: true, text: 'Wavelength (nm, log)', color: '#1f2937', font: { size: 13 } },
-                        grid: { color: '#e5e7eb' },
+                        title: { display: true, text: 'Wavelength (nm, log)', color: '#161616', font: { size: 13 } },
+                        grid: { color: '#e0e0e0' },
                         ticks: {
                             callback: v => [100, 200, 500, 1000, 2000, 5000].includes(v) ? v : ''
                         }
                     },
                     y: {
-                        title: { display: true, text: 'Spectral radiance (W·sr⁻¹·m⁻²·nm⁻¹)', color: '#1f2937', font: { size: 12 } },
-                        grid: { color: '#e5e7eb' }
+                        title: { display: true, text: 'Spectral radiance (W·sr⁻¹·m⁻²·nm⁻¹)', color: '#161616', font: { size: 12 } },
+                        grid: { color: '#e0e0e0' }
                     }
                 },
                 plugins: {
-                    legend: { labels: { color: '#1f2937' } },
-                    title: { display: true, text: 'Planck Spectrum', color: '#1e3a8a', font: { size: 15 } }
+                    legend: { labels: { color: '#161616' } },
+                    title: { display: true, text: 'Planck Spectrum', color: '#0f62fe', font: { size: 15 } }
                 }
             }
         });

--- a/physics/carbon14_dating.html
+++ b/physics/carbon14_dating.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -25,14 +25,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -41,7 +41,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 24px;
         }
@@ -54,11 +54,11 @@
         }
 
         .section-label {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             font-size: 15px;
             margin: 0 0 12px;
-            border-bottom: 2px solid #e0e7ff;
+            border-bottom: 2px solid #edf5ff;
             padding-bottom: 6px;
         }
 
@@ -76,7 +76,7 @@
         }
 
         .control-group label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
             display: flex;
@@ -85,7 +85,7 @@
         }
 
         .control-group label span {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             min-width: 60px;
             text-align: right;
@@ -94,8 +94,8 @@
         input[type="range"] {
             width: 100%;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
         }
@@ -104,24 +104,24 @@
             -webkit-appearance: none;
             width: 18px;
             height: 18px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 18px;
             height: 18px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
         }
 
         .result-box {
-            background: linear-gradient(135deg, #eff6ff, #e0e7ff);
-            border: 1px solid #bfdbfe;
-            border-radius: 10px;
+            background: linear-gradient(135deg, #f4f4f4, #edf5ff);
+            border: 1px solid #d0e2ff;
+            border-radius: 0;
             padding: 18px 22px;
             margin-bottom: 24px;
             text-align: center;
@@ -130,12 +130,12 @@
         .result-age {
             font-size: 32px;
             font-weight: 800;
-            color: #1e3a8a;
+            color: #0f62fe;
             margin-bottom: 2px;
         }
 
         .result-sub {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
         }
 
@@ -148,14 +148,14 @@
 
         .detail-item {
             background: #ffffff;
-            border-radius: 8px;
+            border-radius: 0;
             padding: 10px 14px;
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
         }
 
         .detail-item .label {
             font-size: 11px;
-            color: #9ca3af;
+            color: #8c8c8c;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             font-weight: 600;
@@ -164,18 +164,18 @@
         .detail-item .value {
             font-size: 15px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
             margin-top: 2px;
         }
 
         .explainer {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 18px 22px;
             margin-bottom: 24px;
             font-size: 14px;
-            color: #374151;
+            color: #161616;
             line-height: 1.7;
         }
 
@@ -188,9 +188,9 @@
         }
 
         .formula-box {
-            background: #eff6ff;
-            border: 1px solid #bfdbfe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #d0e2ff;
+            border-radius: 0;
             padding: 16px 22px;
             margin-bottom: 24px;
             overflow-x: auto;
@@ -199,7 +199,7 @@
         .formula-box .formula-title {
             font-size: 12px;
             font-weight: 700;
-            color: #3b82f6;
+            color: #0f62fe;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             margin-bottom: 8px;
@@ -218,19 +218,19 @@
             align-items: center;
             gap: 8px;
             font-size: 13px;
-            color: #374151;
+            color: #161616;
         }
 
         .legend-dot {
             width: 14px;
             height: 14px;
-            border-radius: 3px;
+            border-radius: 0;
             flex-shrink: 0;
         }
 
         a.back-link {
             display: inline-block;
-            color: #3b82f6;
+            color: #0f62fe;
             font-size: 13px;
             text-decoration: none;
             margin-bottom: 18px;
@@ -252,13 +252,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -274,15 +275,15 @@
 
     <div class="legend">
         <div class="legend-item">
-            <div class="legend-dot" style="background:#3b82f6;"></div>
+            <div class="legend-dot" style="background:#0f62fe;"></div>
             <span>C-14 remaining</span>
         </div>
         <div class="legend-item">
-            <div class="legend-dot" style="background:#ef4444;"></div>
+            <div class="legend-dot" style="background:#da1e28;"></div>
             <span>N-14 accumulated</span>
         </div>
         <div class="legend-item">
-            <div class="legend-dot" style="background:#10b981; width:3px; height:14px; border-radius:2px;"></div>
+            <div class="legend-dot" style="background:#24a148; width:3px; height:14px; border-radius: 0;"></div>
             <span>Measured sample</span>
         </div>
     </div>
@@ -378,7 +379,7 @@
                 {
                     label: 'C-14 remaining (N/N₀)',
                     data: c14,
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59,130,246,0.08)',
                     borderWidth: 2.5,
                     pointRadius: 0,
@@ -388,7 +389,7 @@
                 {
                     label: 'N-14 accumulated (N/N₀)',
                     data: n14,
-                    borderColor: '#ef4444',
+                    borderColor: '#da1e28',
                     backgroundColor: 'rgba(239,68,68,0.07)',
                     borderWidth: 2.5,
                     pointRadius: 0,
@@ -398,11 +399,11 @@
                 {
                     label: 'Sample age',
                     data: [],
-                    borderColor: '#10b981',
+                    borderColor: '#24a148',
                     borderWidth: 2,
                     borderDash: [6, 4],
                     pointRadius: 6,
-                    pointBackgroundColor: '#10b981',
+                    pointBackgroundColor: '#24a148',
                     pointBorderColor: '#fff',
                     pointBorderWidth: 2,
                     showLine: true,
@@ -421,7 +422,7 @@
                     title: {
                         display: true,
                         text: 'Time (years)',
-                        color: '#6b7280',
+                        color: '#525252',
                         font: {size: 12}
                     },
                     min: 0,
@@ -429,7 +430,7 @@
                     ticks: {
                         callback: v => (v / 1000).toFixed(0) + ' kyr',
                         maxTicksLimit: 6,
-                        color: '#9ca3af'
+                        color: '#8c8c8c'
                     },
                     grid: {color: 'rgba(0,0,0,0.05)'}
                 },
@@ -437,14 +438,14 @@
                     title: {
                         display: true,
                         text: 'Fraction of N₀',
-                        color: '#6b7280',
+                        color: '#525252',
                         font: {size: 12}
                     },
                     min: 0,
                     max: 1.05,
                     ticks: {
                         callback: v => (v * 100).toFixed(0) + '%',
-                        color: '#9ca3af'
+                        color: '#8c8c8c'
                     },
                     grid: {color: 'rgba(0,0,0,0.05)'}
                 }

--- a/physics/decay_dating.html
+++ b/physics/decay_dating.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -25,14 +25,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin: 0 0 6px;
             font-size: 24px;
@@ -41,7 +41,7 @@
 
         .subtitle {
             text-align: center;
-            color: #6b7280;
+            color: #525252;
             font-size: 14px;
             margin-bottom: 24px;
         }
@@ -54,11 +54,11 @@
         }
 
         .section-label {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             font-size: 15px;
             margin: 0 0 12px;
-            border-bottom: 2px solid #e0e7ff;
+            border-bottom: 2px solid #edf5ff;
             padding-bottom: 6px;
         }
 
@@ -76,7 +76,7 @@
         }
 
         .control-group label {
-            color: #4b5563;
+            color: #525252;
             font-size: 13px;
             font-weight: 600;
             display: flex;
@@ -85,7 +85,7 @@
         }
 
         .control-group label span {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-weight: 700;
             min-width: 60px;
             text-align: right;
@@ -94,8 +94,8 @@
         input[type="range"] {
             width: 100%;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
         }
@@ -104,24 +104,24 @@
             -webkit-appearance: none;
             width: 18px;
             height: 18px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 18px;
             height: 18px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
         }
 
         .result-box {
-            background: linear-gradient(135deg, #eff6ff, #e0e7ff);
-            border: 1px solid #bfdbfe;
-            border-radius: 10px;
+            background: linear-gradient(135deg, #f4f4f4, #edf5ff);
+            border: 1px solid #d0e2ff;
+            border-radius: 0;
             padding: 18px 22px;
             margin-bottom: 24px;
             text-align: center;
@@ -130,12 +130,12 @@
         .result-age {
             font-size: 32px;
             font-weight: 800;
-            color: #1e3a8a;
+            color: #0f62fe;
             margin-bottom: 2px;
         }
 
         .result-sub {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
         }
 
@@ -148,14 +148,14 @@
 
         .detail-item {
             background: #ffffff;
-            border-radius: 8px;
+            border-radius: 0;
             padding: 10px 14px;
-            border: 1px solid #e5e7eb;
+            border: 1px solid #e0e0e0;
         }
 
         .detail-item .label {
             font-size: 11px;
-            color: #9ca3af;
+            color: #8c8c8c;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             font-weight: 600;
@@ -164,18 +164,18 @@
         .detail-item .value {
             font-size: 15px;
             font-weight: 700;
-            color: #1e3a8a;
+            color: #0f62fe;
             margin-top: 2px;
         }
 
         .explainer {
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
             padding: 18px 22px;
             margin-bottom: 24px;
             font-size: 14px;
-            color: #374151;
+            color: #161616;
             line-height: 1.7;
         }
 
@@ -188,9 +188,9 @@
         }
 
         .formula-box {
-            background: #eff6ff;
-            border: 1px solid #bfdbfe;
-            border-radius: 10px;
+            background: #f4f4f4;
+            border: 1px solid #d0e2ff;
+            border-radius: 0;
             padding: 16px 22px;
             margin-bottom: 24px;
             overflow-x: auto;
@@ -199,7 +199,7 @@
         .formula-box .formula-title {
             font-size: 12px;
             font-weight: 700;
-            color: #3b82f6;
+            color: #0f62fe;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             margin-bottom: 8px;
@@ -218,19 +218,19 @@
             align-items: center;
             gap: 8px;
             font-size: 13px;
-            color: #374151;
+            color: #161616;
         }
 
         .legend-dot {
             width: 14px;
             height: 14px;
-            border-radius: 3px;
+            border-radius: 0;
             flex-shrink: 0;
         }
 
         a.back-link {
             display: inline-block;
-            color: #3b82f6;
+            color: #0f62fe;
             font-size: 13px;
             text-decoration: none;
             margin-bottom: 18px;
@@ -252,13 +252,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -274,15 +275,15 @@
 
     <div class="legend">
         <div class="legend-item">
-            <div class="legend-dot" style="background:#3b82f6;"></div>
+            <div class="legend-dot" style="background:#0f62fe;"></div>
             <span>K-40 remaining</span>
         </div>
         <div class="legend-item">
-            <div class="legend-dot" style="background:#ef4444;"></div>
+            <div class="legend-dot" style="background:#da1e28;"></div>
             <span>Ar-40 accumulated</span>
         </div>
         <div class="legend-item">
-            <div class="legend-dot" style="background:#10b981; width:3px; height:14px; border-radius:2px;"></div>
+            <div class="legend-dot" style="background:#24a148; width:3px; height:14px; border-radius: 0;"></div>
             <span>Measured sample</span>
         </div>
     </div>
@@ -384,7 +385,7 @@
                 {
                     label: 'K-40 remaining (N/N₀)',
                     data: k40,
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59,130,246,0.08)',
                     borderWidth: 2.5,
                     pointRadius: 0,
@@ -394,7 +395,7 @@
                 {
                     label: 'Ar-40 accumulated (N/N₀)',
                     data: ar40,
-                    borderColor: '#ef4444',
+                    borderColor: '#da1e28',
                     backgroundColor: 'rgba(239,68,68,0.07)',
                     borderWidth: 2.5,
                     pointRadius: 0,
@@ -404,11 +405,11 @@
                 {
                     label: 'Sample age',
                     data: [],
-                    borderColor: '#10b981',
+                    borderColor: '#24a148',
                     borderWidth: 2,
                     borderDash: [6, 4],
                     pointRadius: 6,
-                    pointBackgroundColor: '#10b981',
+                    pointBackgroundColor: '#24a148',
                     pointBorderColor: '#fff',
                     pointBorderWidth: 2,
                     showLine: true,
@@ -427,7 +428,7 @@
                     title: {
                         display: true,
                         text: 'Time (billion years)',
-                        color: '#6b7280',
+                        color: '#525252',
                         font: {size: 12}
                     },
                     min: 0,
@@ -435,7 +436,7 @@
                     ticks: {
                         callback: v => v.toFixed(1) + ' Ga',
                         maxTicksLimit: 6,
-                        color: '#9ca3af'
+                        color: '#8c8c8c'
                     },
                     grid: {color: 'rgba(0,0,0,0.05)'}
                 },
@@ -443,14 +444,14 @@
                     title: {
                         display: true,
                         text: 'Fraction of N₀',
-                        color: '#6b7280',
+                        color: '#525252',
                         font: {size: 12}
                     },
                     min: 0,
                     max: 1.05,
                     ticks: {
                         callback: v => (v * 100).toFixed(0) + '%',
-                        color: '#9ca3af'
+                        color: '#8c8c8c'
                     },
                     grid: {color: 'rgba(0,0,0,0.05)'}
                 }

--- a/physics/earth_temperature.html
+++ b/physics/earth_temperature.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -22,13 +22,13 @@
             width: 450px;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 24px;
@@ -43,7 +43,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
         }
@@ -52,8 +52,8 @@
             width: 100px;
             padding: 8px 0;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
             transition: background-color 0.3s ease;
@@ -63,28 +63,28 @@
             -webkit-appearance: none;
             width: 16px;
             height: 16px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
             transition: background-color 0.3s ease, box-shadow 0.3s ease;
         }
 
         input[type="range"]:focus::-webkit-slider-thumb {
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+            box-shadow: none;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 16px;
             height: 16px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
             transition: background-color 0.3s ease, box-shadow 0.3s ease;
         }
 
         input[type="range"]:focus::-moz-range-thumb {
-            box-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
+            box-shadow: none;
         }
 
         .value-container {
@@ -96,7 +96,7 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
@@ -104,66 +104,66 @@
         }
 
         #upBtn {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         #upBtn:hover {
-            background: #1e40af;
+            background: #0050e6;
             transform: translateY(-2px);
         }
 
         #downBtn {
-            background: #9ca3af;
+            background: #8c8c8c;
             color: white;
         }
 
         #downBtn:hover {
-            background: #6b7280;
+            background: #525252;
             transform: translateY(-2px);
         }
 
         .temperature-display {
             margin-top: 25px;
             padding: 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
-            color: #374151;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
+            color: #161616;
             font-size: 14px;
             text-align: center;
         }
 
         .temperature-display span {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         canvas {
             margin-top: 20px;
             padding: 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         .explanation {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .explanation h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
             text-align: left;
         }
 
         .explanation p, .explanation ul {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
@@ -175,13 +175,14 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
     <!-- pwa-install-marker -->
     <link rel="icon" type="image/svg+xml" href="../icons/icon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
     <link rel="manifest" href="../manifest.webmanifest">
-    <meta name="theme-color" content="#1e3a8a">
+    <meta name="theme-color" content="#0f62fe">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="Insights">
@@ -261,7 +262,7 @@
                 datasets: [{
                     label: 'Temperature vs. Albedo',
                     data: albedos.map((a, i) => (({x: a, y: temperatures[i]}))),
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59, 130, 246, 0.1)',
                     fill: false,
                     pointRadius: 0
@@ -269,7 +270,7 @@
                     label: 'Current',
                     data: [{x: 0.3, y: calculateTemperature(0.3)}],
                     type: 'scatter',
-                    pointBackgroundColor: '#dc2626',
+                    pointBackgroundColor: '#da1e28',
                     pointRadius: 5
                 }]
             },
@@ -281,33 +282,33 @@
                         title: {
                             display: true,
                             text: 'Albedo',
-                            color: '#1f2937',
+                            color: '#161616',
                             font: {
                                 size: 14
                             }
                         },
                         grid: {
-                            color: '#e5e7eb'
+                            color: '#e0e0e0'
                         }
                     },
                     y: {
                         title: {
                             display: true,
                             text: 'Effective Temperature (°C)',
-                            color: '#1f2937',
+                            color: '#161616',
                             font: {
                                 size: 14
                             }
                         },
                         grid: {
-                            color: '#e5e7eb'
+                            color: '#e0e0e0'
                         }
                     }
                 },
                 plugins: {
                     legend: {
                         labels: {
-                            color: '#1f2937',
+                            color: '#161616',
                             font: {
                                 size: 14
                             }
@@ -316,7 +317,7 @@
                     title: {
                         display: true,
                         text: 'Effective Temperature vs. Albedo',
-                        color: '#1e3a8a',
+                        color: '#0f62fe',
                         font: {
                             size: 16
                         }

--- a/physics/kepler.html
+++ b/physics/kepler.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -25,14 +25,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 22px;
@@ -48,7 +48,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
         }
@@ -56,8 +56,8 @@
         input[type="range"] {
             width: 160px;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
         }
@@ -66,17 +66,17 @@
             -webkit-appearance: none;
             width: 16px;
             height: 16px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 16px;
             height: 16px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
         }
 
@@ -89,15 +89,15 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
-        .arrow-btn.down { background: #9ca3af; }
+        .arrow-btn.down { background: #8c8c8c; }
         .arrow-btn:hover { transform: translateY(-2px); }
 
         .preset-row {
@@ -111,22 +111,22 @@
             flex: 1 1 auto;
             padding: 6px 8px;
             font-size: 12px;
-            border: 1px solid #dbeafe;
-            border-radius: 6px;
-            background: #eff6ff;
-            color: #1e3a8a;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
+            background: #f4f4f4;
+            color: #0f62fe;
             cursor: pointer;
         }
 
-        .preset-row button:hover { background: #dbeafe; }
+        .preset-row button:hover { background: #edf5ff; }
 
         .results {
             margin-top: 20px;
             padding: 15px 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
-            color: #374151;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
+            color: #161616;
             font-size: 14px;
         }
 
@@ -138,15 +138,15 @@
 
         .results .row span:last-child {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         .orbit-stage {
             margin-top: 20px;
             padding: 10px;
             background: #0b1220;
-            border-radius: 10px;
-            border: 1px solid #1e3a8a;
+            border-radius: 0;
+            border: 1px solid #0f62fe;
             display: flex;
             justify-content: center;
         }
@@ -154,31 +154,32 @@
         canvas.chart {
             margin-top: 20px;
             padding: 15px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         .explanation {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .explanation h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .explanation p, .explanation ul {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="calculator">
@@ -290,7 +291,7 @@
                 datasets: [{
                     label: 'Period vs a (current mass)',
                     data: aSamples.map((a, i) => ({ x: a, y: periodSamples[i] })),
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59, 130, 246, 0.1)',
                     fill: false,
                     pointRadius: 0,
@@ -299,7 +300,7 @@
                     label: 'Current',
                     type: 'scatter',
                     data: [{ x: 1, y: 1 }],
-                    pointBackgroundColor: '#dc2626',
+                    pointBackgroundColor: '#da1e28',
                     pointRadius: 5
                 }, {
                     label: 'Solar System planets',
@@ -314,7 +315,7 @@
                         { x: 19.19, y: 84.01 }, // Uranus
                         { x: 30.07, y: 164.8 }  // Neptune
                     ],
-                    pointBackgroundColor: '#f59e0b',
+                    pointBackgroundColor: '#f1c21b',
                     pointRadius: 4
                 }]
             },
@@ -323,22 +324,22 @@
                 scales: {
                     x: {
                         type: 'logarithmic',
-                        title: { display: true, text: 'Semi-major axis a (AU, log)', color: '#1f2937' },
-                        grid: { color: '#e5e7eb' },
+                        title: { display: true, text: 'Semi-major axis a (AU, log)', color: '#161616' },
+                        grid: { color: '#e0e0e0' },
                         min: 0.1, max: 50,
                         ticks: { callback: v => [0.1, 1, 10].includes(v) ? v : '' }
                     },
                     y: {
                         type: 'logarithmic',
-                        title: { display: true, text: 'Period T (years, log)', color: '#1f2937' },
-                        grid: { color: '#e5e7eb' },
+                        title: { display: true, text: 'Period T (years, log)', color: '#161616' },
+                        grid: { color: '#e0e0e0' },
                         min: 0.01, max: 1000,
                         ticks: { callback: v => [0.01, 0.1, 1, 10, 100, 1000].includes(v) ? v : '' }
                     }
                 },
                 plugins: {
-                    legend: { labels: { color: '#1f2937' } },
-                    title: { display: true, text: "T² = a³ — log-log slope of 3/2", color: '#1e3a8a', font: { size: 15 } }
+                    legend: { labels: { color: '#161616' } },
+                    title: { display: true, text: "T² = a³ — log-log slope of 3/2", color: '#0f62fe', font: { size: 15 } }
                 }
             }
         });
@@ -369,7 +370,7 @@
             // Orbit ellipse (centre at canvas centre)
             octx.beginPath();
             octx.ellipse(cx, cy, aAU * scale, b * scale, 0, 0, 2 * Math.PI);
-            octx.strokeStyle = '#3b82f6';
+            octx.strokeStyle = '#0f62fe';
             octx.lineWidth = 1.5;
             octx.stroke();
 
@@ -387,7 +388,7 @@
             octx.arc(starX, starY, 8, 0, 2 * Math.PI);
             const starGrad = octx.createRadialGradient(starX, starY, 1, starX, starY, 12);
             starGrad.addColorStop(0, '#fff7c4');
-            starGrad.addColorStop(0.6, '#f59e0b');
+            starGrad.addColorStop(0.6, '#f1c21b');
             starGrad.addColorStop(1, 'rgba(245, 158, 11, 0)');
             octx.fillStyle = starGrad;
             octx.fill();

--- a/physics/time_dilation.html
+++ b/physics/time_dilation.html
@@ -9,8 +9,8 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #e0e7ff, #f3f4f6);
+            font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             justify-content: center;
@@ -25,14 +25,14 @@
             max-width: 100%;
             background: #ffffff;
             padding: 30px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-            border: 1px solid #e5e7eb;
+            border-radius: 0;
+            box-shadow: none;
+            border: 1px solid #e0e0e0;
             box-sizing: border-box;
         }
 
         h1 {
-            color: #1e3a8a;
+            color: #0f62fe;
             text-align: center;
             margin-bottom: 25px;
             font-size: 22px;
@@ -48,7 +48,7 @@
 
         label {
             flex: 1;
-            color: #4b5563;
+            color: #525252;
             font-size: 14px;
             font-weight: 500;
         }
@@ -56,8 +56,8 @@
         input[type="range"] {
             width: 160px;
             -webkit-appearance: none;
-            background: #d1d5db;
-            border-radius: 8px;
+            background: #c6c6c6;
+            border-radius: 0;
             height: 6px;
             outline: none;
         }
@@ -66,17 +66,17 @@
             -webkit-appearance: none;
             width: 16px;
             height: 16px;
-            background: #3b82f6;
-            border-radius: 50%;
+            background: #0f62fe;
+            border-radius: 0;
             cursor: pointer;
         }
 
         input[type="range"]::-moz-range-thumb {
             width: 16px;
             height: 16px;
-            background: #3b82f6;
+            background: #0f62fe;
             border: none;
-            border-radius: 50%;
+            border-radius: 0;
             cursor: pointer;
         }
 
@@ -89,16 +89,16 @@
         .arrow-btn {
             padding: 6px 10px;
             border: none;
-            border-radius: 6px;
+            border-radius: 0;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
         }
 
         .arrow-btn.down {
-            background: #9ca3af;
+            background: #8c8c8c;
         }
 
         .arrow-btn:hover { transform: translateY(-2px); }
@@ -114,22 +114,22 @@
             flex: 1 1 auto;
             padding: 6px 8px;
             font-size: 12px;
-            border: 1px solid #dbeafe;
-            border-radius: 6px;
-            background: #eff6ff;
-            color: #1e3a8a;
+            border: 1px solid #edf5ff;
+            border-radius: 0;
+            background: #f4f4f4;
+            color: #0f62fe;
             cursor: pointer;
         }
 
-        .preset-row button:hover { background: #dbeafe; }
+        .preset-row button:hover { background: #edf5ff; }
 
         .results {
             margin-top: 20px;
             padding: 15px 20px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
-            color: #374151;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
+            color: #161616;
             font-size: 14px;
         }
 
@@ -141,33 +141,33 @@
 
         .results .row span:last-child {
             font-weight: 600;
-            color: #1f2937;
+            color: #161616;
         }
 
         canvas {
             margin-top: 20px;
             padding: 15px;
-            background: #f9fafb;
-            border-radius: 10px;
-            border: 1px solid #e5e7eb;
+            background: #ffffff;
+            border-radius: 0;
+            border: 1px solid #e0e0e0;
         }
 
         .explanation {
             margin-top: 20px;
             padding: 15px;
-            background: #eff6ff;
-            border-radius: 10px;
-            border: 1px solid #dbeafe;
+            background: #f4f4f4;
+            border-radius: 0;
+            border: 1px solid #edf5ff;
         }
 
         .explanation h2 {
-            color: #1e3a8a;
+            color: #0f62fe;
             font-size: 16px;
             margin-bottom: 10px;
         }
 
         .explanation p, .explanation ul {
-            color: #6b7280;
+            color: #525252;
             font-size: 13px;
             margin: 5px 0;
         }
@@ -180,20 +180,21 @@
 
         .unit-toggle button {
             padding: 5px 10px;
-            border: 1px solid #d1d5db;
-            border-radius: 6px;
-            background: #f3f4f6;
-            color: #4b5563;
+            border: 1px solid #c6c6c6;
+            border-radius: 0;
+            background: #f4f4f4;
+            color: #525252;
             cursor: pointer;
             font-size: 12px;
         }
 
         .unit-toggle button.active {
-            background: #1e3a8a;
+            background: #0f62fe;
             color: white;
-            border-color: #1e3a8a;
+            border-color: #0f62fe;
         }
     </style>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="calculator">
@@ -274,7 +275,7 @@
                 datasets: [{
                     label: 'γ vs β',
                     data: betas.map((b, i) => ({ x: b, y: gammas[i] })),
-                    borderColor: '#3b82f6',
+                    borderColor: '#0f62fe',
                     backgroundColor: 'rgba(59, 130, 246, 0.1)',
                     fill: false,
                     pointRadius: 0,
@@ -283,7 +284,7 @@
                     label: 'Current',
                     type: 'scatter',
                     data: [{ x: 0.5, y: gamma(0.5) }],
-                    pointBackgroundColor: '#dc2626',
+                    pointBackgroundColor: '#da1e28',
                     pointRadius: 5
                 }]
             },
@@ -293,18 +294,18 @@
                     x: {
                         type: 'linear',
                         min: 0, max: 1,
-                        title: { display: true, text: 'β = v / c', color: '#1f2937' },
-                        grid: { color: '#e5e7eb' }
+                        title: { display: true, text: 'β = v / c', color: '#161616' },
+                        grid: { color: '#e0e0e0' }
                     },
                     y: {
                         min: 1, max: 10,
-                        title: { display: true, text: 'Lorentz factor γ', color: '#1f2937' },
-                        grid: { color: '#e5e7eb' }
+                        title: { display: true, text: 'Lorentz factor γ', color: '#161616' },
+                        grid: { color: '#e0e0e0' }
                     }
                 },
                 plugins: {
-                    legend: { labels: { color: '#1f2937' } },
-                    title: { display: true, text: 'Lorentz factor γ vs velocity', color: '#1e3a8a', font: { size: 15 } }
+                    legend: { labels: { color: '#161616' } },
+                    title: { display: true, text: 'Lorentz factor γ vs velocity', color: '#0f62fe', font: { size: 15 } }
                 }
             }
         });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,394 @@
+/* IBM Carbon Design System — shared tokens & base styles
+   Source: design.md (IBM brand canvas) */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap');
+
+:root {
+  /* Brand & accent */
+  --ibm-primary: #0f62fe;
+  --ibm-on-primary: #ffffff;
+  --ibm-blue-60: #0043ce;
+  --ibm-blue-80: #002d9c;
+  --ibm-blue-hover: #0050e6;
+
+  /* Surfaces */
+  --ibm-canvas: #ffffff;
+  --ibm-surface-1: #f4f4f4;
+  --ibm-surface-2: #e0e0e0;
+  --ibm-inverse-canvas: #161616;
+  --ibm-inverse-surface-1: #262626;
+
+  /* Text */
+  --ibm-ink: #161616;
+  --ibm-ink-muted: #525252;
+  --ibm-ink-subtle: #8c8c8c;
+  --ibm-inverse-ink: #ffffff;
+  --ibm-inverse-ink-muted: #c6c6c6;
+
+  /* Hairlines */
+  --ibm-hairline: #e0e0e0;
+  --ibm-hairline-strong: #161616;
+
+  /* Semantic */
+  --ibm-success: #24a148;
+  --ibm-warning: #f1c21b;
+  --ibm-error: #da1e28;
+
+  /* Type stack */
+  --ibm-font: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  --ibm-font-mono: 'IBM Plex Mono', 'SF Mono', Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--ibm-canvas);
+  color: var(--ibm-ink);
+  font-family: var(--ibm-font);
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: 0.16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--ibm-primary);
+  text-decoration: none;
+}
+a:hover { color: var(--ibm-blue-60); text-decoration: underline; }
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--ibm-ink);
+  letter-spacing: 0;
+  margin: 0 0 16px;
+}
+h1 { font-size: 42px; font-weight: 300; line-height: 1.2; }
+h2 { font-size: 32px; font-weight: 400; line-height: 1.25; }
+h3 { font-size: 24px; font-weight: 400; line-height: 1.33; }
+h4 { font-size: 20px; font-weight: 400; line-height: 1.4; }
+
+@media (max-width: 672px) {
+  h1 { font-size: 32px; }
+  h2 { font-size: 26px; }
+  h3 { font-size: 20px; }
+}
+
+/* IBM utility bar (slim ribbon above top nav) */
+.ibm-utility-bar {
+  background: var(--ibm-surface-1);
+  color: var(--ibm-ink-muted);
+  font-size: 12px;
+  letter-spacing: 0.32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--ibm-hairline);
+}
+
+/* IBM top navigation */
+.ibm-top-nav {
+  background: var(--ibm-canvas);
+  color: var(--ibm-ink);
+  height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--ibm-hairline);
+  font-size: 14px;
+  letter-spacing: 0.16px;
+}
+.ibm-top-nav .ibm-wordmark {
+  font-weight: 600;
+  letter-spacing: -0.5px;
+  color: var(--ibm-ink);
+  margin-right: 32px;
+  font-size: 16px;
+}
+.ibm-top-nav .ibm-wordmark a { color: inherit; text-decoration: none; }
+.ibm-top-nav nav a {
+  color: var(--ibm-ink);
+  padding: 0 16px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+.ibm-top-nav nav a:hover {
+  background: var(--ibm-surface-1);
+  text-decoration: none;
+}
+
+/* IBM page shell */
+.ibm-page {
+  max-width: 1312px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+@media (max-width: 672px) {
+  .ibm-page { padding: 32px 16px; }
+  .ibm-utility-bar { display: none; }
+  .ibm-top-nav { padding: 0 16px; }
+  .ibm-top-nav nav a { padding: 0 12px; }
+}
+
+/* Buttons (Carbon-style: square, no shadow) */
+.ibm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--ibm-font);
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.16px;
+  line-height: 1.29;
+  padding: 12px 16px;
+  border: 1px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.11s ease;
+}
+.ibm-btn-primary {
+  background: var(--ibm-primary);
+  color: var(--ibm-on-primary);
+}
+.ibm-btn-primary:hover { background: var(--ibm-blue-hover); color: #fff; text-decoration: none; }
+.ibm-btn-primary:active { background: var(--ibm-blue-80); }
+
+.ibm-btn-secondary {
+  background: var(--ibm-ink);
+  color: var(--ibm-inverse-ink);
+}
+.ibm-btn-secondary:hover { background: var(--ibm-inverse-surface-1); color: #fff; text-decoration: none; }
+
+.ibm-btn-tertiary {
+  background: var(--ibm-canvas);
+  color: var(--ibm-primary);
+  border-color: var(--ibm-primary);
+}
+.ibm-btn-tertiary:hover { background: var(--ibm-primary); color: #fff; text-decoration: none; }
+
+/* Carbon-style text input: surface-1 fill, hairline bottom rule, no rounding */
+.ibm-input {
+  background: var(--ibm-surface-1);
+  color: var(--ibm-ink);
+  font-family: var(--ibm-font);
+  font-size: 16px;
+  letter-spacing: 0.16px;
+  line-height: 1.5;
+  padding: 11px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--ibm-ink-muted);
+  border-radius: 0;
+  width: 100%;
+}
+.ibm-input:focus {
+  outline: none;
+  border-bottom: 2px solid var(--ibm-primary);
+  padding-bottom: 10px;
+}
+
+/* Card grid (used by index.html) */
+.ibm-card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--ibm-hairline);
+  border: 1px solid var(--ibm-hairline);
+}
+@media (max-width: 1056px) { .ibm-card-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 672px)  { .ibm-card-grid { grid-template-columns: 1fr; } }
+
+.ibm-tile {
+  background: var(--ibm-canvas);
+  color: var(--ibm-ink);
+  padding: 24px;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  min-height: 168px;
+  transition: background-color 0.11s ease;
+  position: relative;
+}
+.ibm-tile:hover {
+  background: var(--ibm-surface-1);
+  color: var(--ibm-ink);
+  text-decoration: none;
+}
+.ibm-tile .ibm-tile-eyebrow {
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-ink-muted);
+  margin: 0 0 8px;
+}
+.ibm-tile h3 {
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--ibm-ink);
+  margin: 0 0 12px;
+  letter-spacing: 0;
+}
+.ibm-tile p {
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-ink-muted);
+  margin: 0;
+  flex-grow: 1;
+}
+.ibm-tile-arrow {
+  margin-top: 16px;
+  color: var(--ibm-primary);
+  font-size: 14px;
+  letter-spacing: 0.16px;
+}
+
+/* Hero block */
+.ibm-hero {
+  padding: 96px 0 64px;
+}
+.ibm-hero h1 {
+  font-size: 60px;
+  font-weight: 300;
+  line-height: 1.17;
+  letter-spacing: -0.4px;
+  color: var(--ibm-ink);
+  max-width: 900px;
+  margin: 0 0 24px;
+}
+.ibm-hero .ibm-eyebrow {
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-ink-muted);
+  margin: 0 0 16px;
+}
+.ibm-hero p.ibm-lead {
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--ibm-ink-muted);
+  max-width: 720px;
+  margin: 0 0 32px;
+}
+@media (max-width: 1056px) { .ibm-hero h1 { font-size: 48px; } }
+@media (max-width: 672px)  { .ibm-hero { padding: 48px 0 32px; } .ibm-hero h1 { font-size: 36px; } }
+
+.ibm-section-eyebrow {
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-ink-muted);
+  margin: 0 0 16px;
+}
+
+.ibm-section {
+  padding: 64px 0;
+  border-top: 1px solid var(--ibm-hairline);
+}
+.ibm-section:first-of-type { border-top: 0; }
+
+/* Footer */
+.ibm-footer {
+  background: var(--ibm-inverse-canvas);
+  color: var(--ibm-inverse-ink-muted);
+  padding: 64px 24px 32px;
+  font-size: 14px;
+  letter-spacing: 0.16px;
+}
+.ibm-footer .ibm-footer-inner {
+  max-width: 1312px;
+  margin: 0 auto;
+}
+.ibm-footer .ibm-wordmark {
+  color: var(--ibm-inverse-ink);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.5px;
+  margin: 0 0 24px;
+}
+.ibm-footer p { margin: 0 0 8px; }
+.ibm-footer a { color: var(--ibm-inverse-ink); }
+.ibm-footer a:hover { color: var(--ibm-inverse-ink-muted); }
+
+/* Demo-page conventions */
+.ibm-demo-page {
+  background: var(--ibm-canvas);
+  min-height: 100vh;
+  display: block;
+}
+.ibm-demo-shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+.ibm-demo-shell.wide { max-width: 1056px; }
+.ibm-back-link {
+  display: inline-block;
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-primary);
+  margin-bottom: 24px;
+}
+
+/* Form row helper used inside demos */
+.ibm-form-row {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin: 16px 0;
+  flex-wrap: wrap;
+}
+.ibm-form-row label {
+  flex: 1;
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  color: var(--ibm-ink);
+  min-width: 140px;
+}
+
+/* ----------------------------------------------------------------
+   Mobile safety: prevent horizontal page scroll so range sliders
+   inside demo cards capture horizontal drag gestures correctly.
+   ---------------------------------------------------------------- */
+html, body {
+  overflow-x: hidden;
+  max-width: 100vw;
+}
+
+/* Range sliders should capture horizontal drag rather than letting
+   the page scroll sideways. On mobile we force full width so the
+   touch target is the full viewport. */
+input[type="range"] {
+  touch-action: pan-y;
+  box-sizing: border-box;
+}
+@media (max-width: 600px) {
+  input[type="range"] { width: 100% !important; max-width: 100% !important; }
+}
+
+/* Common demo containers go full-bleed on small screens so sliders
+   have the full viewport to work in. */
+@media (max-width: 600px) {
+  body { padding: 0 !important; }
+  .calculator,
+  .container,
+  .card,
+  .app,
+  .panel,
+  .stage,
+  .wrap {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    border-left: 0 !important;
+    border-right: 0 !important;
+  }
+  /* Form/label rows should not enforce a min-width that exceeds the
+     viewport; let labels wrap above their inputs. */
+  .input-group label,
+  .ibm-form-row label,
+  label[for] { min-width: 0 !important; }
+}


### PR DESCRIPTION
Apply the visual identity documented in design.md across the whole site:
white canvas, IBM Plex Sans (light-weight 300 for display), IBM Blue (#0f62fe)
as the single accent, square 0px corners, and 1px hairlines instead of shadows.

- Add shared styles.css with Carbon design tokens, base type, .ibm-*
  utility classes (top-nav, hero, tile grid, footer, buttons, inputs).
- Rewrite index.html as a Carbon-style landing page: utility bar,
  top navigation, hero with light-weight headline, topic-filtered
  4-up tile grid, charcoal footer.
- Re-skin all 16 math/ and physics/ demos with the Carbon palette,
  IBM Plex Sans, square corners, and hairline borders (no drop shadows).
- Fix mobile sliders: prevent horizontal page scroll so range inputs
  capture touch drags correctly, force demo containers to full-bleed
  on small screens.
- Update CLAUDE.md to point future work at design.md as the source of
  truth for visual design.