### PR TITLE
Remove redundant top-nav topic links

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,6 @@
     </div>
     <header class="ibm-top-nav" role="banner">
         <div class="ibm-wordmark"><a href="index.html">Insights</a></div>
-        <nav aria-label="Primary">
-            <a href="#topics" data-nav-filter="all">Topics</a>
-            <a href="#topics" data-nav-filter="math">Math</a>
-            <a href="#topics" data-nav-filter="physics">Physics</a>
-        </nav>
     </header>
 
     <main class="ibm-page">
@@ -159,10 +154,6 @@
 
         document.querySelectorAll('.topic-filter button').forEach(btn => {
             btn.addEventListener('click', () => setFilter(btn.dataset.filter));
-        });
-
-        document.querySelectorAll('[data-nav-filter]').forEach(link => {
-            link.addEventListener('click', () => setFilter(link.dataset.navFilter));
         });
     </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -109,18 +109,6 @@ h4 { font-size: 20px; font-weight: 400; line-height: 1.4; }
   font-size: 16px;
 }
 .ibm-top-nav .ibm-wordmark a { color: inherit; text-decoration: none; }
-.ibm-top-nav nav a {
-  color: var(--ibm-ink);
-  padding: 0 16px;
-  height: 48px;
-  display: inline-flex;
-  align-items: center;
-  text-decoration: none;
-}
-.ibm-top-nav nav a:hover {
-  background: var(--ibm-surface-1);
-  text-decoration: none;
-}
 
 /* IBM page shell */
 .ibm-page {
@@ -133,7 +121,6 @@ h4 { font-size: 20px; font-weight: 400; line-height: 1.4; }
   .ibm-page { padding: 32px 16px; }
   .ibm-utility-bar { display: none; }
   .ibm-top-nav { padding: 0 16px; }
-  .ibm-top-nav nav a { padding: 0 12px; }
 }
 
 /* Buttons (Carbon-style: square, no shadow) */


### PR DESCRIPTION
The Topics/Math/Physics links in the top nav duplicated the
All/Math/Physics tab strip beside the card grid. Drop the nav
links (and their dead CSS) so the tab strip is the single
filter control.

https://claude.ai/code/session_01D3XKGmgHnUgqrJaVYyzi2t