### PR TITLE
Add numerical and operator keypad to RPN calculator

### DIFF
--- a/math/polish.html
+++ b/math/polish.html
@@ -84,7 +84,7 @@
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
-            transition: background-color 0.3s ease, transform 0.2s ease;
+            transition: background-color 0.15s ease;
             min-width: 80px;
         }
 
@@ -95,17 +95,60 @@
 
         #enterBtn:hover {
             background: #0050e6;
-            transform: translateY(-2px);
         }
 
         #clearBtn {
-            background: #8c8c8c;
+            background: #161616;
             color: white;
         }
 
         #clearBtn:hover {
-            background: #525252;
-            transform: translateY(-2px);
+            background: #393939;
+        }
+
+        .keypad {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 1px;
+            margin: 20px 0;
+            background: #e0e0e0;
+            border: 1px solid #e0e0e0;
+        }
+
+        .keypad button {
+            min-width: 0;
+            padding: 16px 0;
+            font-size: 16px;
+            font-weight: 400;
+            letter-spacing: 0.16px;
+            min-height: 48px;
+        }
+
+        .keypad .key-num {
+            background: #ffffff;
+            color: #161616;
+        }
+
+        .keypad .key-num:hover {
+            background: #f4f4f4;
+        }
+
+        .keypad .key-back {
+            background: #f4f4f4;
+            color: #161616;
+        }
+
+        .keypad .key-back:hover {
+            background: #e0e0e0;
+        }
+
+        .keypad .key-op {
+            background: #161616;
+            color: #ffffff;
+        }
+
+        .keypad .key-op:hover {
+            background: #393939;
         }
 
         #stackDisplay {
@@ -198,6 +241,12 @@
                 min-width: 70px;
             }
 
+            .keypad button {
+                padding: 14px 0;
+                font-size: 15px;
+                min-width: 0;
+            }
+
             #stackDisplay {
                 padding: 15px;
                 font-size: 13px;
@@ -245,6 +294,13 @@
                 min-width: 60px;
             }
 
+            .keypad button {
+                padding: 12px 0;
+                font-size: 14px;
+                min-width: 0;
+                min-height: 44px;
+            }
+
             #stackDisplay {
                 padding: 10px;
                 font-size: 12px;
@@ -288,7 +344,29 @@
             <label for="input">Enter number or operator:</label>
             <input type="text" id="input" placeholder="e.g., 3, +, -" aria-label="Enter number or operator">
         </div>
-        
+
+        <div class="keypad" role="group" aria-label="Calculator keypad">
+            <button type="button" class="key-num" data-digit="7">7</button>
+            <button type="button" class="key-num" data-digit="8">8</button>
+            <button type="button" class="key-num" data-digit="9">9</button>
+            <button type="button" class="key-op" data-op="+" aria-label="Add">+</button>
+
+            <button type="button" class="key-num" data-digit="4">4</button>
+            <button type="button" class="key-num" data-digit="5">5</button>
+            <button type="button" class="key-num" data-digit="6">6</button>
+            <button type="button" class="key-op" data-op="-" aria-label="Subtract">−</button>
+
+            <button type="button" class="key-num" data-digit="1">1</button>
+            <button type="button" class="key-num" data-digit="2">2</button>
+            <button type="button" class="key-num" data-digit="3">3</button>
+            <button type="button" class="key-op" data-op="*" aria-label="Multiply">×</button>
+
+            <button type="button" class="key-num" data-digit="0">0</button>
+            <button type="button" class="key-num" data-digit=".">.</button>
+            <button type="button" class="key-back" id="backBtn" aria-label="Backspace">⌫</button>
+            <button type="button" class="key-op" data-op="/" aria-label="Divide">÷</button>
+        </div>
+
         <div class="button-group">
             <button id="enterBtn" aria-label="Process input">Enter</button>
             <button id="clearBtn" aria-label="Clear stack">Clear</button>
@@ -395,6 +473,7 @@
 
         const enterBtn = document.getElementById('enterBtn');
         const clearBtn = document.getElementById('clearBtn');
+        const backBtn = document.getElementById('backBtn');
         const inputField = document.getElementById('input');
 
         enterBtn.addEventListener('click', processInput);
@@ -403,6 +482,31 @@
             if (e.key === 'Enter') {
                 processInput();
             }
+        });
+
+        document.querySelectorAll('.keypad [data-digit]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const d = btn.dataset.digit;
+                if (d === '.' && inputField.value.includes('.')) return;
+                inputField.value += d;
+                inputField.focus();
+            });
+        });
+
+        document.querySelectorAll('.keypad [data-op]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                if (inputField.value.trim() !== '') {
+                    calculator.process(inputField.value);
+                    inputField.value = '';
+                }
+                calculator.process(btn.dataset.op);
+                inputField.focus();
+            });
+        });
+
+        backBtn.addEventListener('click', () => {
+            inputField.value = inputField.value.slice(0, -1);
+            inputField.focus();
         });
     </script>
 </body>

--- a/math/polish.html
+++ b/math/polish.html
@@ -320,6 +320,16 @@
             letter-spacing: 0.16px;
         }
 
+        .example-divider {
+            font-size: 11px;
+            color: #8c8c8c;
+            letter-spacing: 0.32px;
+            text-transform: uppercase;
+            padding: 16px 0 0;
+            margin-top: 4px;
+            border-top: 1px solid #161616;
+        }
+
         /* Responsive adjustments */
         @media (max-width: 600px) {
             .calculator {
@@ -465,6 +475,11 @@
                 font-size: 11px;
                 min-width: 56px;
             }
+
+            .example-divider {
+                font-size: 10px;
+                padding-top: 12px;
+            }
         }
     </style>
     <link rel="stylesheet" href="../styles.css">
@@ -578,6 +593,44 @@
                     <p class="ex-note">Deep nesting collapses to a flat sequence. No paren-counting, no ambiguity.</p>
                 </div>
                 <button type="button" class="ex-run" data-presses="1↵2+3*4↵5+6*+" aria-label="Run example: nested expression">Run</button>
+            </div>
+
+            <div class="example-divider">Fractions and decimals</div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">1/2 + 1/4 = 0.75</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>1</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd class="kbd-op">÷</kbd><kbd>1</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">÷</kbd><kbd class="kbd-op">+</kbd></code></div>
+                    <p class="ex-note">Each fraction reduces to a decimal on the stack; the final + adds them.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="1↵2/1↵4/+" aria-label="Run example: one half plus one quarter">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">(8 + 4) / (5 − 2) = 4</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>8</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">+</kbd><kbd>5</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd class="kbd-op">−</kbd><kbd class="kbd-op">÷</kbd></code></div>
+                    <p class="ex-note">Numerator and denominator each collapse to a single value, then divide.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="8↵4+5↵2-/" aria-label="Run example: eight plus four over five minus two">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">1.5 × 2.5 + 0.25 = 4</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>1</kbd><kbd>.</kbd><kbd>5</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd>.</kbd><kbd>5</kbd><kbd class="kbd-op">×</kbd><kbd>0</kbd><kbd>.</kbd><kbd>2</kbd><kbd>5</kbd><kbd class="kbd-op">+</kbd></code></div>
+                    <p class="ex-note">The decimal point is just another digit — type it and continue.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="1.5↵2.5*0.25+" aria-label="Run example: one point five times two point five plus zero point two five">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">(1/2 + 1/3) × 6 = 5</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>1</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd class="kbd-op">÷</kbd><kbd>1</kbd><kbd class="kbd-enter">↵</kbd><kbd>3</kbd><kbd class="kbd-op">÷</kbd><kbd class="kbd-op">+</kbd><kbd>6</kbd><kbd class="kbd-op">×</kbd></code></div>
+                    <p class="ex-note">A classic calculator needs three pairs of parentheses; RPN keeps moving forward.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="1↵2/1↵3/+6*" aria-label="Run example: one half plus one third, times six">Run</button>
             </div>
         </div>
     </div>

--- a/math/polish.html
+++ b/math/polish.html
@@ -202,6 +202,124 @@
             text-align: center;
         }
 
+        .examples {
+            margin-top: 20px;
+            padding: 20px;
+            background: #ffffff;
+            border: 1px solid #e0e0e0;
+        }
+
+        .examples h3 {
+            color: #161616;
+            font-size: 16px;
+            font-weight: 400;
+            margin: 0 0 8px 0;
+            letter-spacing: 0;
+        }
+
+        .examples-intro {
+            color: #525252;
+            font-size: 13px;
+            line-height: 1.5;
+            margin: 0 0 8px 0;
+            letter-spacing: 0.16px;
+        }
+
+        .example {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 14px 0;
+            border-top: 1px solid #e0e0e0;
+            flex-wrap: wrap;
+        }
+
+        .example-pair {
+            flex: 1;
+            min-width: 180px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .ex-row {
+            display: flex;
+            align-items: baseline;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .ex-label {
+            font-size: 11px;
+            color: #8c8c8c;
+            letter-spacing: 0.32px;
+            text-transform: uppercase;
+            min-width: 56px;
+            flex-shrink: 0;
+        }
+
+        .ex-classic,
+        .ex-rpn {
+            font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+            font-size: 14px;
+            color: #161616;
+            letter-spacing: 0;
+        }
+
+        .ex-rpn kbd {
+            display: inline-block;
+            background: #f4f4f4;
+            border: 1px solid #e0e0e0;
+            padding: 1px 6px;
+            margin: 0 1px;
+            font-family: inherit;
+            font-size: 12px;
+            color: #161616;
+            min-width: 18px;
+            text-align: center;
+        }
+
+        .ex-rpn kbd.kbd-op {
+            background: #161616;
+            border-color: #161616;
+            color: #ffffff;
+        }
+
+        .ex-rpn kbd.kbd-enter {
+            color: #0f62fe;
+            border-color: #0f62fe;
+            background: #ffffff;
+        }
+
+        .ex-run {
+            background: #161616;
+            color: #ffffff;
+            padding: 8px 14px;
+            font-size: 12px;
+            font-weight: 400;
+            letter-spacing: 0.16px;
+            min-width: 64px;
+            border: none;
+            cursor: pointer;
+            transition: background-color 0.15s ease;
+        }
+
+        .ex-run:hover {
+            background: #393939;
+        }
+
+        .ex-run:disabled {
+            background: #c6c6c6;
+            cursor: not-allowed;
+        }
+
+        .ex-note {
+            font-size: 12px;
+            color: #525252;
+            margin-top: 4px;
+            letter-spacing: 0.16px;
+        }
+
         /* Responsive adjustments */
         @media (max-width: 600px) {
             .calculator {
@@ -319,6 +437,34 @@
             .instructions p {
                 font-size: 11px;
             }
+
+            .examples {
+                padding: 12px;
+            }
+
+            .examples h3 {
+                font-size: 14px;
+            }
+
+            .examples-intro {
+                font-size: 12px;
+            }
+
+            .ex-classic,
+            .ex-rpn {
+                font-size: 13px;
+            }
+
+            .ex-label {
+                min-width: 48px;
+                font-size: 10px;
+            }
+
+            .ex-run {
+                padding: 6px 12px;
+                font-size: 11px;
+                min-width: 56px;
+            }
         }
     </style>
     <link rel="stylesheet" href="../styles.css">
@@ -383,6 +529,56 @@
             <p>Enter numbers or operators (+, -, *, /) one at a time and press Enter or click the Enter button.</p>
             <p>Example: To calculate 3 + 4, enter: 3 [Enter], 4 [Enter], + [Enter].</p>
             <p>Results are shown in the stack below. Use the Clear button to reset the stack.</p>
+        </div>
+
+        <div class="examples">
+            <h3>From classic to RPN</h3>
+            <p class="examples-intro">A classic calculator forces you to track parentheses and operator precedence. RPN evaluates onto a stack — left to right, no parentheses, no precedence rules. Press <strong>Run</strong> on each example to watch the stack do the work.</p>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">3 + 4 = 7</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>3</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">+</kbd></code></div>
+                    <p class="ex-note">Push 3, push 4, then add the top two.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="3↵4+" aria-label="Run example: three plus four">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">2 + 3 × 4 = 14</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>3</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">×</kbd><kbd>2</kbd><kbd class="kbd-op">+</kbd></code></div>
+                    <p class="ex-note">No precedence rules — multiply first because you keyed it first.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="3↵4*2+" aria-label="Run example: two plus three times four">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">(3 + 4) × 5 = 35</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>3</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">+</kbd><kbd>5</kbd><kbd class="kbd-op">×</kbd></code></div>
+                    <p class="ex-note">Parentheses disappear — the stack remembers the intermediate 7.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="3↵4+5*" aria-label="Run example: three plus four, times five">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">(3 + 4) × (5 − 2) = 21</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>3</kbd><kbd class="kbd-enter">↵</kbd><kbd>4</kbd><kbd class="kbd-op">+</kbd><kbd>5</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd class="kbd-op">−</kbd><kbd class="kbd-op">×</kbd></code></div>
+                    <p class="ex-note">Two sub-results sit on the stack. The final × pops both.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="3↵4+5↵2-*" aria-label="Run example: three plus four, times five minus two">Run</button>
+            </div>
+
+            <div class="example">
+                <div class="example-pair">
+                    <div class="ex-row"><span class="ex-label">Classic</span><code class="ex-classic">((1 + 2) × 3) + ((4 + 5) × 6) = 63</code></div>
+                    <div class="ex-row"><span class="ex-label">RPN</span><code class="ex-rpn"><kbd>1</kbd><kbd class="kbd-enter">↵</kbd><kbd>2</kbd><kbd class="kbd-op">+</kbd><kbd>3</kbd><kbd class="kbd-op">×</kbd><kbd>4</kbd><kbd class="kbd-enter">↵</kbd><kbd>5</kbd><kbd class="kbd-op">+</kbd><kbd>6</kbd><kbd class="kbd-op">×</kbd><kbd class="kbd-op">+</kbd></code></div>
+                    <p class="ex-note">Deep nesting collapses to a flat sequence. No paren-counting, no ambiguity.</p>
+                </div>
+                <button type="button" class="ex-run" data-presses="1↵2+3*4↵5+6*+" aria-label="Run example: nested expression">Run</button>
+            </div>
         </div>
     </div>
 
@@ -507,6 +703,50 @@
         backBtn.addEventListener('click', () => {
             inputField.value = inputField.value.slice(0, -1);
             inputField.focus();
+        });
+
+        let exampleRunning = false;
+        const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+        async function runExample(presses) {
+            if (exampleRunning) return;
+            exampleRunning = true;
+            const runBtns = document.querySelectorAll('.ex-run');
+            runBtns.forEach(b => b.disabled = true);
+
+            calculator.clear();
+            inputField.value = '';
+            await sleep(300);
+
+            for (const p of presses) {
+                if (p === '↵') {
+                    if (inputField.value.trim() !== '') {
+                        await sleep(350);
+                        calculator.process(inputField.value);
+                        inputField.value = '';
+                    }
+                } else if (/[0-9.]/.test(p)) {
+                    await sleep(300);
+                    inputField.value += p;
+                } else {
+                    if (inputField.value.trim() !== '') {
+                        await sleep(350);
+                        calculator.process(inputField.value);
+                        inputField.value = '';
+                    }
+                    await sleep(350);
+                    calculator.process(p);
+                }
+            }
+
+            exampleRunning = false;
+            runBtns.forEach(b => b.disabled = false);
+        }
+
+        document.querySelectorAll('.ex-run').forEach(btn => {
+            btn.addEventListener('click', () => {
+                runExample(btn.dataset.presses);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
Tap-driven entry alongside the existing input field: 0–9 and . append
to the input, ⌫ deletes a character, and operators auto-push the
pending number before applying. Keypad uses Carbon tokens — square
corners, charcoal operator keys, white digit keys with hairline
gridlines.