### PR TITLE
Suppress mobile OS keyboard on RPN input

### DIFF
--- a/math/polish.html
+++ b/math/polish.html
@@ -151,27 +151,128 @@
             background: #393939;
         }
 
+        .calc-body {
+            display: grid;
+            grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+            gap: 12px;
+            align-items: stretch;
+            margin: 20px 0;
+        }
+
+        .calc-body .keypad {
+            margin: 0;
+        }
+
         #stackDisplay {
-            margin-top: 25px;
-            padding: 20px;
-            background: #ffffff;
-            border-radius: 0;
-            border: 1px solid #e0e0e0;
-            color: #161616;
-            font-size: 14px;
-            min-height: 50px;
-        }
-
-        #stackDisplay p {
-            margin: 10px 0;
+            margin: 0;
+            padding: 0;
+            background: #161616;
+            color: #f4f4f4;
+            border: 1px solid #161616;
             display: flex;
-            justify-content: space-between;
-            flex-wrap: wrap;
+            flex-direction: column;
+            min-height: 200px;
+            overflow: hidden;
         }
 
-        #stackDisplay span {
+        .stack-label {
+            font-size: 10px;
+            letter-spacing: 0.32px;
+            text-transform: uppercase;
+            color: #8d8d8d;
+            padding: 8px 12px;
+            border-bottom: 1px solid #393939;
+            flex: 0 0 auto;
+        }
+
+        .stack-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .stack-item {
+            font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+            font-size: 15px;
+            padding: 8px 12px;
+            text-align: right;
+            border-top: 1px solid #262626;
+            color: #c6c6c6;
+            background: transparent;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+
+        .stack-item:first-child {
+            border-top: none;
+            color: #ffffff;
+            background: #262626;
             font-weight: 600;
-            color: #161616;
+        }
+
+        .stack-empty {
+            padding: 12px;
+            text-align: right;
+            color: #6f6f6f;
+            font-size: 12px;
+            font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+        }
+
+        .stack-item.anim-push {
+            animation: stackPushIn 280ms cubic-bezier(0.2, 0.8, 0.4, 1);
+        }
+
+        .stack-item.anim-flash {
+            animation: stackFlash 720ms ease-out;
+        }
+
+        .stack-item.shake {
+            animation: stackShake 420ms ease-in-out;
+            background: #4d2929 !important;
+            color: #ffd7d9 !important;
+        }
+
+        @keyframes stackPushIn {
+            from {
+                transform: translateY(-14px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        @keyframes stackShake {
+            0%, 100% { transform: translateX(0); }
+            15% { transform: translateX(-4px); }
+            35% { transform: translateX(4px); }
+            55% { transform: translateX(-3px); }
+            75% { transform: translateX(3px); }
+        }
+
+        @keyframes stackFlash {
+            0% {
+                background: #0f62fe;
+                color: #ffffff;
+                transform: scale(1.04);
+            }
+            100% {
+                background: #262626;
+                color: #ffffff;
+                transform: scale(1);
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .stack-item.anim-push,
+            .stack-item.anim-flash,
+            .stack-item.shake {
+                animation: none;
+            }
         }
 
         .instructions {
@@ -375,9 +476,21 @@
                 min-width: 0;
             }
 
+            .calc-body {
+                gap: 8px;
+            }
+
             #stackDisplay {
-                padding: 15px;
+                min-height: 180px;
+            }
+
+            .stack-item {
                 font-size: 13px;
+                padding: 6px 8px;
+            }
+
+            .stack-label {
+                padding: 6px 8px;
             }
 
             .instructions h3 {
@@ -429,10 +542,23 @@
                 min-height: 44px;
             }
 
+            .calc-body {
+                gap: 6px;
+                grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+            }
+
             #stackDisplay {
-                padding: 10px;
+                min-height: 160px;
+            }
+
+            .stack-item {
                 font-size: 12px;
-                min-height: 40px;
+                padding: 5px 7px;
+            }
+
+            .stack-label {
+                padding: 5px 7px;
+                font-size: 9px;
             }
 
             .instructions {
@@ -506,35 +632,38 @@
             <input type="text" id="input" inputmode="none" placeholder="e.g., 3, +, -" aria-label="Enter number or operator">
         </div>
 
-        <div class="keypad" role="group" aria-label="Calculator keypad">
-            <button type="button" class="key-num" data-digit="7">7</button>
-            <button type="button" class="key-num" data-digit="8">8</button>
-            <button type="button" class="key-num" data-digit="9">9</button>
-            <button type="button" class="key-op" data-op="+" aria-label="Add">+</button>
+        <div class="calc-body">
+            <div class="keypad" role="group" aria-label="Calculator keypad">
+                <button type="button" class="key-num" data-digit="7">7</button>
+                <button type="button" class="key-num" data-digit="8">8</button>
+                <button type="button" class="key-num" data-digit="9">9</button>
+                <button type="button" class="key-op" data-op="+" aria-label="Add">+</button>
 
-            <button type="button" class="key-num" data-digit="4">4</button>
-            <button type="button" class="key-num" data-digit="5">5</button>
-            <button type="button" class="key-num" data-digit="6">6</button>
-            <button type="button" class="key-op" data-op="-" aria-label="Subtract">−</button>
+                <button type="button" class="key-num" data-digit="4">4</button>
+                <button type="button" class="key-num" data-digit="5">5</button>
+                <button type="button" class="key-num" data-digit="6">6</button>
+                <button type="button" class="key-op" data-op="-" aria-label="Subtract">−</button>
 
-            <button type="button" class="key-num" data-digit="1">1</button>
-            <button type="button" class="key-num" data-digit="2">2</button>
-            <button type="button" class="key-num" data-digit="3">3</button>
-            <button type="button" class="key-op" data-op="*" aria-label="Multiply">×</button>
+                <button type="button" class="key-num" data-digit="1">1</button>
+                <button type="button" class="key-num" data-digit="2">2</button>
+                <button type="button" class="key-num" data-digit="3">3</button>
+                <button type="button" class="key-op" data-op="*" aria-label="Multiply">×</button>
 
-            <button type="button" class="key-num" data-digit="0">0</button>
-            <button type="button" class="key-num" data-digit=".">.</button>
-            <button type="button" class="key-back" id="backBtn" aria-label="Backspace">⌫</button>
-            <button type="button" class="key-op" data-op="/" aria-label="Divide">÷</button>
+                <button type="button" class="key-num" data-digit="0">0</button>
+                <button type="button" class="key-num" data-digit=".">.</button>
+                <button type="button" class="key-back" id="backBtn" aria-label="Backspace">⌫</button>
+                <button type="button" class="key-op" data-op="/" aria-label="Divide">÷</button>
+            </div>
+
+            <div id="stackDisplay" aria-live="polite">
+                <div class="stack-label">Stack</div>
+                <ol class="stack-list" id="stackList"></ol>
+            </div>
         </div>
 
         <div class="button-group">
             <button id="enterBtn" aria-label="Process input">Enter</button>
             <button id="clearBtn" aria-label="Clear stack">Clear</button>
-        </div>
-        
-        <div id="stackDisplay" aria-live="polite">
-            <p>Stack: <span id="stackContent"></span></p>
         </div>
 
         <div id="error" role="alert"></div>
@@ -640,66 +769,118 @@
             constructor() {
                 this.stack = [];
                 this.errorDisplay = document.getElementById('error');
-                this.stackContent = document.getElementById('stackContent');
+                this.stackList = document.getElementById('stackList');
+                this.queue = [];
+                this.processing = false;
+                this.renderStack();
             }
 
             process(token) {
+                return new Promise(resolve => {
+                    this.queue.push({ token, resolve });
+                    if (!this.processing) this._runQueue();
+                });
+            }
+
+            async _runQueue() {
+                this.processing = true;
+                while (this.queue.length) {
+                    const { token, resolve } = this.queue.shift();
+                    try {
+                        await this._processOne(token);
+                    } finally {
+                        resolve();
+                    }
+                }
+                this.processing = false;
+            }
+
+            async _processOne(token) {
                 this.errorDisplay.style.display = 'none';
-                token = token.trim();
+                token = (token ?? '').toString().trim();
 
                 if (!token) {
                     this.showError("Input cannot be empty");
                     return;
                 }
 
-                if (token !== '' && !isNaN(Number(token))) {
+                if (!isNaN(Number(token))) {
                     this.stack.push(Number(token));
-                } else {
-                    if (this.stack.length < 2) {
-                        this.showError("Not enough operands!");
-                        return;
-                    }
-                    const b = this.stack.pop();
-                    const a = this.stack.pop();
-                    
-                    const round = n => parseFloat(n.toPrecision(10));
-                    switch(token) {
-                        case '+':
-                            this.stack.push(round(a + b));
-                            break;
-                        case '-':
-                            this.stack.push(round(a - b));
-                            break;
-                        case '*':
-                            this.stack.push(round(a * b));
-                            break;
-                        case '/':
-                            if (b === 0) {
-                                this.showError("Division by zero!");
-                                this.stack.push(a);
-                                this.stack.push(b);
-                                return;
-                            }
-                            this.stack.push(round(a / b));
-                            break;
-                        default:
-                            this.showError("Unknown operator!");
-                            this.stack.push(a);
-                            this.stack.push(b);
-                            return;
-                    }
+                    this.renderStack({ animateTop: 'push' });
+                    await this._sleep(140);
+                    return;
                 }
-                this.updateDisplay();
+
+                if (this.stack.length < 2) {
+                    this.showError("Not enough operands!");
+                    return;
+                }
+
+                const round = n => parseFloat(n.toPrecision(10));
+                const a = this.stack[this.stack.length - 2];
+                const b = this.stack[this.stack.length - 1];
+                let result;
+                switch (token) {
+                    case '+': result = round(a + b); break;
+                    case '-': result = round(a - b); break;
+                    case '*': result = round(a * b); break;
+                    case '/':
+                        if (b === 0) {
+                            this.showError("Division by zero!");
+                            return;
+                        }
+                        result = round(a / b);
+                        break;
+                    default:
+                        this.showError("Unknown operator!");
+                        return;
+                }
+
+                const items = this.stackList.querySelectorAll('.stack-item');
+                if (items[0]) items[0].classList.add('shake');
+                if (items[1]) items[1].classList.add('shake');
+                await this._sleep(440);
+
+                this.stack.pop();
+                this.stack.pop();
+                this.stack.push(result);
+                this.renderStack({ animateTop: 'flash' });
+                await this._sleep(220);
             }
 
             clear() {
                 this.stack = [];
+                this.queue = [];
                 this.errorDisplay.style.display = 'none';
-                this.updateDisplay();
+                this.renderStack();
             }
 
-            updateDisplay() {
-                this.stackContent.textContent = this.stack.join(' ');
+            renderStack({ animateTop = null } = {}) {
+                this.stackList.innerHTML = '';
+                if (this.stack.length === 0) {
+                    const li = document.createElement('li');
+                    li.className = 'stack-empty';
+                    li.textContent = '— empty —';
+                    this.stackList.appendChild(li);
+                    return;
+                }
+                for (let i = this.stack.length - 1; i >= 0; i--) {
+                    const li = document.createElement('li');
+                    li.className = 'stack-item';
+                    if (i === this.stack.length - 1 && animateTop) {
+                        li.classList.add(animateTop === 'flash' ? 'anim-flash' : 'anim-push');
+                    }
+                    li.textContent = this._format(this.stack[i]);
+                    this.stackList.appendChild(li);
+                }
+            }
+
+            _format(n) {
+                return Number(n).toString();
+            }
+
+            _sleep(ms) {
+                return new Promise(r => setTimeout(r, ms));
             }
 
             showError(message) {
@@ -774,21 +955,21 @@
             for (const p of presses) {
                 if (p === '↵') {
                     if (inputField.value.trim() !== '') {
-                        await sleep(350);
-                        calculator.process(inputField.value);
+                        await sleep(300);
+                        await calculator.process(inputField.value);
                         inputField.value = '';
                     }
                 } else if (/[0-9.]/.test(p)) {
-                    await sleep(300);
+                    await sleep(280);
                     inputField.value += p;
                 } else {
                     if (inputField.value.trim() !== '') {
-                        await sleep(350);
-                        calculator.process(inputField.value);
+                        await sleep(300);
+                        await calculator.process(inputField.value);
                         inputField.value = '';
                     }
-                    await sleep(350);
-                    calculator.process(p);
+                    await sleep(280);
+                    await calculator.process(p);
                 }
             }
 

--- a/math/polish.html
+++ b/math/polish.html
@@ -503,7 +503,7 @@
         
         <div class="input-group">
             <label for="input">Enter number or operator:</label>
-            <input type="text" id="input" placeholder="e.g., 3, +, -" aria-label="Enter number or operator">
+            <input type="text" id="input" inputmode="none" placeholder="e.g., 3, +, -" aria-label="Enter number or operator">
         </div>
 
         <div class="keypad" role="group" aria-label="Calculator keypad">


### PR DESCRIPTION
The RPN calculator has its own on-screen numeric/operator keypad,
so the device keyboard isn't needed. inputmode="none" hides it
while preserving focus, paste, and desktop physical-key entry.