### PR TITLE
RPN: slow down example playback

### DIFF
--- a/math/polish.html
+++ b/math/polish.html
@@ -985,24 +985,24 @@
             runBtns.forEach(b => b.disabled = true);
 
             calculator.clear();
-            await sleep(300);
+            await sleep(500);
 
             for (const p of presses) {
                 if (p === '↵') {
                     if (calculator.buffer !== '') {
-                        await sleep(300);
+                        await sleep(600);
                         flashKey('#enterBtn');
                         await calculator.enter();
                     }
                 } else if (/[0-9.]/.test(p)) {
-                    await sleep(280);
+                    await sleep(500);
                     flashKey(`.keypad [data-digit="${p}"]`);
                     calculator.inputDigit(p);
                 } else {
                     if (calculator.buffer !== '') {
-                        await sleep(300);
+                        await sleep(700);
                     } else {
-                        await sleep(280);
+                        await sleep(550);
                     }
                     flashKey(`.keypad [data-op="${p}"]`);
                     await calculator.applyOp(p);


### PR DESCRIPTION
## Summary

Bump the inter-press pauses in the worked-example runner so each step is easier to follow:

- digits: 280 → 500ms
- op without buffer: 280 → 550ms
- op or Enter that auto-commits a buffer: 300 → 600/700ms
- initial post-clear pause: 300 → 500ms

## Test plan
- [ ] Run a single-step example (e.g. `3 + 4`) — perceptibly slower, key flashes are easier to track.
- [ ] Run the deepest example (`((1 + 2) × 3) + ((4 + 5) × 6) = 63`) — pacing feels deliberate, not laggy.

https://claude.ai/code/session_01WtH8Cz27zUHQrxfRAXw679

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtH8Cz27zUHQrxfRAXw679)_