### PR TITLE
Remove polyfill.io from all remaining physics demos

### DIFF
--- a/physics/blackbody.html
+++ b/physics/blackbody.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blackbody Spectrum (Planck's Law)</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {

--- a/physics/carbon14_dating.html
+++ b/physics/carbon14_dating.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Carbon-14 Dating</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {

--- a/physics/decay_dating.html
+++ b/physics/decay_dating.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>K-Ar Rock Dating</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {

--- a/physics/earth_temperature.html
+++ b/physics/earth_temperature.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Planet Effective Temperature Calculator</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {

--- a/physics/kepler.html
+++ b/physics/kepler.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kepler's Third Law — Orbital Period</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {

--- a/physics/time_dilation.html
+++ b/physics/time_dilation.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Relativistic Time Dilation</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         body {


### PR DESCRIPTION
## Problem

`polyfill.io` now requires authentication, blocking MathJax from rendering on six physics pages.

## Changes

Removes the dead `<script src="https://polyfill.io/...">` tag from:

- `physics/blackbody.html`
- `physics/earth_temperature.html`
- `physics/kepler.html`
- `physics/time_dilation.html`
- `physics/carbon14_dating.html`
- `physics/decay_dating.html`

MathJax 3 does not require polyfill.io — it was only carried over from older MathJax 2 setups. The `milankovitch_globe.html` page was already fixed in #37.

## Test plan

- [ ] MathJax formulas still render on all six pages
- [ ] No browser console errors about blocked/failed script loads

https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v)_