### PR TITLE
Add PR preview deploys; switch production to gh-pages branch

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,29 @@
+# Deploy a live preview of each PR to:
+#   https://rastermanden.github.io/insights/pr-preview/pr-{N}/
+# Preview is removed automatically when the PR is closed or merged.
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: .
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,43 +1,32 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Deploy static content to the gh-pages branch (root).
+# PR previews land at pr-preview/pr-{N}/ via pr-preview.yml.
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          # Upload entire repository
-          path: '.'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: .
+          clean: true
+          # Never wipe PR preview subdirectories on production deploys
+          clean-exclude: |
+            pr-preview


### PR DESCRIPTION
## What this does

Adds live PR preview deployments at:
```
https://rastermanden.github.io/insights/pr-preview/pr-{N}/
```

Every PR gets a sticky comment posted automatically with its preview URL. The subdirectory is removed when the PR closes or merges.

## Changes

### `static.yml` (modified)
Switches the production deploy from `actions/deploy-pages` (artifact-based, root only) to `JamesIves/github-pages-deploy-action`, which pushes to a `gh-pages` branch. Uses `clean-exclude: pr-preview` so production deploys never wipe open PR previews.

### `pr-preview.yml` (new)
Uses `rossjrw/pr-preview-action`. On PR open/sync → deploys to `gh-pages/pr-preview/pr-{N}/` and posts a sticky comment. On PR close/merge → deletes the subdirectory.

## ⚠️ One manual step required after merge

The production deploy mechanism changes from "GitHub Actions artifact" to "gh-pages branch". After merging you need to update the Pages source **once**:

1. Go to **Settings → Pages**
2. Under **Source**, change from `GitHub Actions` → `Deploy from a branch`
3. Set branch: `gh-pages`, folder: `/ (root)`
4. Save

The first push to `main` after merge will create the `gh-pages` branch and the site will be live again within a minute or two.

https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v)_