### PR TITLE
Fix JS syntax error causing blank globe

### DIFF
--- a/physics/milankovitch_globe.html
+++ b/physics/milankovitch_globe.html
@@ -515,14 +515,14 @@ const earthGroup = new THREE.Group();
 scene.add(earthGroup);
 
 // Axis indicator — thin line through the poles
-const axisLine = (() => {
-    const geo = new THREE.BufferGeometry().setFromPoints([
-        new THREE.Vector3(0, -1.4, 0),
-        new THREE.Vector3(0,  1.4, 0)
-    ]);
-    return new THREE.Line(geo,
-        new THREE.LineBasicMaterial({ color: 0x6699ff, transparent: true, opacity: 0.45 }));
-}());
+const axisGeo = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, -1.4, 0),
+    new THREE.Vector3(0,  1.4, 0)
+]);
+const axisLine = new THREE.Line(
+    axisGeo,
+    new THREE.LineBasicMaterial({ color: 0x6699ff, transparent: true, opacity: 0.45 })
+);
 earthGroup.add(axisLine);
 
 // Texture canvas (equirectangular projection, 1024×512)


### PR DESCRIPTION
## Root cause

Arrow function IIFEs written in Crockford style — `(() => { ... }())` — are rejected by strict JS parsers. The axis line was declared this way:

```js
const axisLine = (() => {
    ...
}());   // ← SyntaxError: Unexpected token '('
```

This threw a `SyntaxError` before any Three.js code ran, so the entire inline script was dead and the canvas stayed blank.

## Fix

Replaced with plain variable declarations — no IIFE needed at all:

```js
const axisGeo = new THREE.BufferGeometry().setFromPoints([...]);
const axisLine = new THREE.Line(axisGeo, material);
```

`node --check` now passes cleanly on the extracted inline script.

## Preview

The PR preview workflow will post a live URL below shortly.

https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01RufjLVe2HQBZS4VRQzRL7v)_